### PR TITLE
docs(plans): migrate roadmap + 13 plan files in-tree under docs/plans/

### DIFF
--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -20,7 +20,7 @@ Live status of canopy's planned work. Update this file as milestones progress; e
 
 **Goal:** ship the typed multi-repo agent surface canopy was always meant to be — recovery from setup failures, per-workspace customization, bot-comment tracking, cross-session memory, and a provider-injection pattern that makes Linear-vs-GitHub-Issues a configuration choice instead of a fork.
 
-**Why now:** the dogfood transcript at `~/projects/canopy/canopy-improvement-research.md` exposed three load-bearing gaps (setup didn't propagate across machines, bot comments aren't first-class, no per-workspace customization). Phil's [issue #5](https://github.com/ashmitb95/canopy/issues/5) added a fourth (Linear-vs-GitHub-Issues forking pressure). This epic closes all four.
+**Why now:** the dogfood transcript at `~/projects/canopy/canopy-improvement-research.md` exposed three load-bearing gaps (setup didn't propagate across machines, bot comments aren't first-class, no per-workspace customization). [Issue #5](https://github.com/ashmitb95/canopy/issues/5) added a fourth (Linear-vs-GitHub-Issues forking pressure). This epic closes all four.
 
 ### Core milestones (in dependency order)
 
@@ -35,7 +35,7 @@ Live status of canopy's planned work. Update this file as milestones progress; e
 - [ ] 🟦 **M4 — Historian** — [historian.md](historian.md) · P1 · ~5-6d · depends on M3
   Cross-session feature memory at `.canopy/memory/<feature>.md`. Auto-read on `canopy switch`.
 - [ ] 🟦 **M5 — Issue-provider scaffold** — see [providers-arch.md §7](providers-arch.md) · P1 · ~3-4d · depends on M0
-  Linear refactored into the contract; GitHub Issues backend. Closes Phil's ask in [#5](https://github.com/ashmitb95/canopy/issues/5).
+  Linear refactored into the contract; GitHub Issues backend. Closes [#5](https://github.com/ashmitb95/canopy/issues/5).
 
 ### Quality-of-life additions (slot in alongside or after the core)
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -1,0 +1,84 @@
+# Canopy Roadmap — Epic & Milestone Index
+
+Live status of canopy's planned work. Update this file as milestones progress; each plan's frontmatter is the per-plan source of truth, this doc is the rolled-up dashboard.
+
+**Last updated:** 2026-05-02
+**Roadmap:** [roadmap.md](roadmap.md) — full architecture context, cross-cutting decisions, sequencing rationale
+
+## Status legend
+
+| Glyph | Meaning |
+|---|---|
+| 🟦 | queued — not started |
+| 🟨 | in-progress — actively being worked |
+| ✅ | shipped — merged to main |
+| ⛔ | blocked — waiting on a dependency or external decision |
+
+---
+
+## Epic — Agent surface + dogfood-failure recoveries (2026-05)
+
+**Goal:** ship the typed multi-repo agent surface canopy was always meant to be — recovery from setup failures, per-workspace customization, bot-comment tracking, cross-session memory, and a provider-injection pattern that makes Linear-vs-GitHub-Issues a configuration choice instead of a fork.
+
+**Why now:** the dogfood transcript at `~/projects/canopy/canopy-improvement-research.md` exposed three load-bearing gaps (setup didn't propagate across machines, bot comments aren't first-class, no per-workspace customization). Phil's [issue #5](https://github.com/ashmitb95/canopy/issues/5) added a fourth (Linear-vs-GitHub-Issues forking pressure). This epic closes all four.
+
+### Core milestones (in dependency order)
+
+- [ ] 🟦 **M0 — Architecture: provider injection** — [providers-arch.md](providers-arch.md) · P0 · ~1d
+  Provider-injection contract for issue providers (Linear, GitHub Issues, JIRA shape). Design reference; code lands in M5.
+- [ ] 🟦 **M1 — `canopy doctor`** — [doctor.md](doctor.md) · P0 · ~3-4d
+  State-file integrity + install-staleness recovery. 15 diagnostic categories, single `canopy doctor` command, `--version` handshake.
+- [ ] 🟦 **M2 — Augment skill** — [augments.md](augments.md) · P1 · ~2-3d · depends on M1
+  Per-workspace customization via `[augments]` block in canopy.toml. New `augment-canopy` skill teaches the agent how to mutate config.
+- [ ] 🟦 **M3 — Bot-comment tracking** — [bot-tracking.md](bot-tracking.md) · P1 · ~3d · depends on M2
+  Distinguish bot vs human review comments, `commit --address <id>`, new `awaiting_bot_resolution` state.
+- [ ] 🟦 **M4 — Historian** — [historian.md](historian.md) · P1 · ~5-6d · depends on M3
+  Cross-session feature memory at `.canopy/memory/<feature>.md`. Auto-read on `canopy switch`.
+- [ ] 🟦 **M5 — Issue-provider scaffold** — see [providers-arch.md §7](providers-arch.md) · P1 · ~3-4d · depends on M0
+  Linear refactored into the contract; GitHub Issues backend. Closes Phil's ask in [#5](https://github.com/ashmitb95/canopy/issues/5).
+
+### Quality-of-life additions (slot in alongside or after the core)
+
+- [ ] 🟦 **M6 — Worktree bootstrap** — [worktree-bootstrap.md](worktree-bootstrap.md) · P2 · ~2d · depends on M1
+- [ ] 🟦 **M7 — Sidebar single-tree (extension)** — [sidebar-single-tree.md](sidebar-single-tree.md) · P2 · ~1d
+- [ ] 🟦 **M8 — Wave 2.4 `ship`** — [wave-2-4-ship.md](wave-2-4-ship.md) · P2 · ~2-3d · depends on M3
+- [ ] 🟦 **M9 — Wave 4 `draft_replies`** — [wave-4-draft-replies.md](wave-4-draft-replies.md) · P2 · ~2d · depends on M3
+- [ ] 🟦 **M10 — CI status integration** — [ci-status.md](ci-status.md) · P2 · ~2d · depends on M3
+- [ ] 🟦 **M11 — Action drawer (extension)** — [action-drawer.md](action-drawer.md) · P3 · ~3-4d · depends on M8 + M9
+- [ ] 🟦 **M12 — `canopy conflicts`** — [cross-feature-conflicts.md](cross-feature-conflicts.md) · P3 · ~1-2d
+
+### Shipped
+
+- [x] ✅ **Wave 2.3 — `commit` + `push`** — [archive/wave-2-3-commit-push.md](archive/wave-2-3-commit-push.md) · shipped 2026-04-26
+
+---
+
+## Effort summary
+
+| Bucket | Milestones | Estimate |
+|---|---|---|
+| Core (M0–M5) | 6 | ~17–20 days |
+| Quality-of-life (M6–M12) | 7 | ~13–18 days |
+| **Total queued** | **13** | **~30–38 days** |
+
+---
+
+## How to update this index
+
+When a milestone changes state:
+
+1. Update its checkbox (`[ ]` → `[x]` once shipped).
+2. Update its glyph (🟦 → 🟨 → ✅).
+3. Update the plan file's frontmatter (`status: queued` → `in-progress` → `shipped`). The two should always agree; frontmatter is the per-plan source of truth, this dashboard is the rolled-up view.
+4. When shipped: move the plan to `archive/` and append the ship date to the entry below the "Shipped" heading.
+
+If manual sync becomes painful, a small `scripts/sync-index.py` can read frontmatter from each plan and regenerate this file. Defer until that's actually annoying.
+
+## Decision log (epic-level)
+
+Things decided during planning that don't fit any single milestone:
+
+- **2026-05-02:** "canopy upgrade" absorbed into [doctor.md](doctor.md) — same Issue/repair pattern; one unified command beats two.
+- **2026-05-02:** Provider-injection scoped to issue providers only in v1 (M0+M5). Bot-author / CI / code-review / IDE-format / pre-commit-framework adoption deferred behind a < 5% effort cap.
+- **2026-05-02:** Historian's "decisions" capture uses hybrid mechanism — explicit MCP tool call (primary) + Stop-hook tail-parse (backup). Format-only too unreliable; tool-only misses free-text decisions.
+- **2026-05-02:** Tracking via in-tree docs instead of GitHub issues. Plan files live at `docs/plans/`; this file is the epic dashboard.

--- a/docs/plans/action-drawer.md
+++ b/docs/plans/action-drawer.md
@@ -1,3 +1,10 @@
+---
+status: queued
+priority: P3
+effort: ~3-4d
+depends_on: ["wave-2-4-ship.md", "wave-4-draft-replies.md"]
+---
+
 # Action Drawer — Per-Feature Dashboard Rebuild to Mockup Spec
 
 ## Mental model

--- a/docs/plans/action-drawer.md
+++ b/docs/plans/action-drawer.md
@@ -1,0 +1,239 @@
+# Action Drawer — Per-Feature Dashboard Rebuild to Mockup Spec
+
+## Mental model
+
+The current per-feature dashboard (post-Wave 7 phase I) is a single-column webview with four cards: Branches, Linear, Review, Recent commits. The mockup at `vscode-extension/mockups/action-drawer.html` calls for something fundamentally different: a **3-column dashboard** with a 360px right rail (the "action drawer") containing a state summary table and 5 grouped action sections (~16 actions total).
+
+This plan rebuilds the dashboard to match the mockup. It's not a polish pass — the layout, the content surface, and the action set all change.
+
+**This plan assumes prerequisite backends are done:**
+- Wave 2.3 (`commit` + `push`) — see `2026-04-26-canopy-wave-2-3-commit-push.md`
+- Wave 4 (`draft_replies`) — see `2026-04-26-canopy-wave-4-draft-replies.md`
+- Wave 2.4 (`ship`) — see `2026-04-26-canopy-wave-2-4-ship.md` (optional but unlocks the "Ship feature" capstone action)
+
+If a backend isn't ready when this plan executes, that action button gets dropped from the drawer for the initial release — `git grep "WAVE-2-3-DEP" src/canopy/` etc. to find tagged blocks.
+
+---
+
+## Layout spec (from mockup)
+
+```
+┌────────────────────────────────────────────────────────────────────────┐
+│ BRIDGE  compass · workspace ~/projects/canopy · lamps · theme toggle   │
+├──────────────────────────────────────┬─────────────────────────────────┤
+│                                      │                                 │
+│   CENTER PANE                        │   RIGHT RAIL (360px)            │
+│                                      │                                 │
+│   Breadcrumb · Dashboard · SIN-12    │   ┌───────────────────────────┐ │
+│                                      │   │ AVAILABLE ACTIONS         │ │
+│   ● SIN-12-search                    │   │ sin-12-search             │ │
+│   "Add /search endpoint…"            │   ├───────────────────────────┤ │
+│   [in main] [needs work] SIN-12 ↗    │   │ STATE     │ in_progress   │ │
+│   last touched 12m ago               │   │ SLOT      │ canonical     │ │
+│                                      │   │ DIRTY     │ 3 files       │ │
+│   ┌────────────┐ ┌────────────┐      │   │ UNPUSHED  │ 2 commits     │ │
+│   │ backend    │ │ frontend   │      │   │ PRs       │ 2 open        │ │
+│   │ branch:    │ │ branch:    │      │   │ ACTIONABLE│ 3 threads     │ │
+│   │ SIN-12-…   │ │ SIN-12-…   │      │   │ PREFLIGHT │ ✓ green       │ │
+│   │ 3 dirty    │ │ 1 dirty    │      │   ├───────────────────────────┤ │
+│   │ 2 actionbl │ │ 1 actionbl │      │   │ REVIEW                    │ │
+│   │ PR #142 ↗  │ │ PR #58 ↗   │      │   │  ▶ Address comments…  ★   │ │
+│   └────────────┘ └────────────┘      │   │  ▶ Draft replies          │ │
+│                                      │   │  ▶ Defer all              │ │
+│   ACTIONABLE THREADS (3)             │   ├───────────────────────────┤ │
+│   ┌──────────────────────────────┐   │   │ WRITE                     │ │
+│   │ backend · src/api/search.py  │   │   │  ▶ Run preflight          │ │
+│   │ alice · 2h ago               │   │   │  ▶ Commit + push          │ │
+│   │ "rename foo to bar"          │   │   │  ▶ Stash dirty work       │ │
+│   │ [Jump] [Reply] [Done] [Defer]│   │   ├───────────────────────────┤ │
+│   └──────────────────────────────┘   │   │ SLOT                      │ │
+│   ... 2 more threads                  │   │  ▶ Move to a worktree     │ │
+│                                      │   │  ▶ Hibernate              │ │
+│                                      │   │  ▶ Add docs to lane       │ │
+│                                      │   │  ▶ Remove repo from lane  │ │
+│                                      │   ├───────────────────────────┤ │
+│                                      │   │ INSPECT                   │ │
+│                                      │   │  ▶ Open in IDE            │ │
+│                                      │   │  ▶ View full diff vs main │ │
+│                                      │   │  ▶ Show resolved threads  │ │
+│                                      │   ├───────────────────────────┤ │
+│                                      │   │ CONFIGURE                 │ │
+│                                      │   │  ▶ Re-link Linear issue   │ │
+│                                      │   │  ▶ Done — archive lane ⚠  │ │
+│                                      │   └───────────────────────────┘ │
+└──────────────────────────────────────┴─────────────────────────────────┘
+```
+
+**Grid:** `grid-template-columns: 1fr 360px`. Right rail fixed width, scrollable. Center pane scrollable independently. Both share the bridge header.
+
+**Theme:** navy (primary) + minimal (alt). Colors per the existing `themes/types.ts` token set (extended with `--bot`, `--on-station`, `--hot` if not present).
+
+---
+
+## Action wiring matrix
+
+Every action div in the drawer posts a typed message to the extension; the extension calls the corresponding MCP tool. Most map 1:1.
+
+| Group | Action label | postMessage type | MCP call | Notes |
+|---|---|---|---|---|
+| Review | Address comments in Claude *(★ recommended when actionable > 0)* | `addressInClaude` | `linear_get_issue` + `review_comments` → build prompt → launch Claude Code via existing `launchClaudeWorkflow` URI | Already partial; finalize the prompt template |
+| Review | Draft replies for addressed threads | `draftReplies` | `draft_replies(feature)` (Wave 4) | Open results in a quick-pick or modal; user posts via `gh pr comment` (manual for v1) |
+| Review | Defer all | `deferAll` | (none — local state) | Write `{<feature>: deferred_until}` to `.canopy/state/deferred.json`; dashboard hides the threads section for 24h |
+| Write | Run preflight | `runPreflight` | `preflight()` | Already wired in current dashboard |
+| Write | Commit + push | `commitAndPush` | `commit(message)` then `push()` (both Wave 2.3) | Quick-pick first asks for commit message; on success show toast |
+| Write | Stash dirty work | `stashDirty` | `stash_save_feature(feature)` | Already wired in canopyClient as `client.stashSaveFeature` |
+| Slot | Move to a worktree | `moveToWorktree` | `switch(feature)` (active rotation default) | When canonical is X, "switch to Y" creates Y's worktree if needed; reuse existing |
+| Slot | Hibernate (branch only) | `hibernate` | `switch(<some-other-feature>, release_current=true)` | Caller picks which feature becomes canonical; if no obvious choice, prompt |
+| Slot | Add docs to lane | `addDocsToLane` | `worktree_create(feature, repo='docs')` | Requires `docs` to be a known repo in workspace |
+| Slot | Remove repo from lane | `removeRepoFromLane` | `feature_remove_repo(feature, repo)` | **No backend exists.** Tag with `WAVE-FUTURE-DEP`; hide button if tool not registered. |
+| Inspect | Open in IDE | `openInIde` | `feature_paths(feature)` then `vscode.openFolder` per path | Reuse the existing `canopy.openInIde` command |
+| Inspect | View full diff vs main | `viewDiff` | `feature_diff(feature)` | Already wired; render in a new webview panel |
+| Inspect | Show likely-resolved threads | `showResolvedThreads` | `review_comments(feature, include_resolved=true)` | Toggle in-place; today's `review_filter` already classifies; expose the secondary list |
+| Configure | Re-link Linear issue | `relinkLinear` | `linear_my_issues(50)` → user picks → `feature_link_linear(feature, issue)` | Same flow as today's "Pick from my Linear issues" but allow change-not-just-add |
+| Configure | Done — archive lane | `featureDone` | `feature_done(feature)` | Existing; add a confirmation modal because of red highlight |
+
+---
+
+## Files to touch
+
+### New
+
+- `vscode-extension/src/webview/dashboard/` — split the existing single-file dashboard into a folder. Each section becomes its own renderer:
+  - `index.ts` — exports `DashboardPanel` (the panel class itself; cache + lifecycle stays here)
+  - `shell.ts` — base HTML + CSS (extracted from current `baseHtml`)
+  - `bridge.ts` — bridge header renderer
+  - `header.ts` — feature title + badges (refactored from current `renderHeader`)
+  - `repoCards.ts` — center pane repo grid (NEW)
+  - `threads.ts` — center pane threads list (NEW)
+  - `drawer.ts` — right rail renderer: summary table + 5 action groups (NEW; bulk of new code)
+  - `skeletons.ts` — extracted skeleton helpers
+- `vscode-extension/src/webview/dashboard/themes.css` — extracted CSS, with both navy + minimal token sets
+
+### Modified / replaced
+
+- `vscode-extension/src/webview/dashboardPanel.ts` — slim to a re-export of `./dashboard/index.ts` (or delete and update extension.ts imports). Keeps the public surface stable for `extension.ts`.
+- `vscode-extension/src/canopyClient.ts` — add the few missing client methods:
+  - `commit(message, opts)` — wraps `commit` MCP tool (Wave 2.3)
+  - `push(opts)` — wraps `push` MCP tool (Wave 2.3)
+  - `draftReplies(feature)` — wraps `draft_replies` (Wave 4)
+  - `featureRemoveRepo(feature, repo)` — wraps `feature_remove_repo` (FUTURE; behind a try/catch + hide-button-on-missing-tool fallback)
+- `vscode-extension/src/types.ts` — add the new return types for the new client methods.
+- `vscode-extension/package.json` — bump version (probably `0.5.0` for layout-rewrite scope).
+- `vscode-extension/src/extension.ts` — no changes if `DashboardPanel` re-exports cleanly; otherwise update import path.
+
+---
+
+## Tasks (rough sequence)
+
+### T1 — Restructure: dashboard folder + extract existing renderers
+
+Move the current dashboardPanel.ts content into the new folder structure. Each existing function becomes its own file with the same exported signature. Verify the dashboard still renders identically afterwards (no behavior change yet).
+
+Commits at this stage: structural only, behavior unchanged.
+
+### T2 — Bridge header + 3-column shell
+
+Build `bridge.ts` (compass icon, workspace path, theme toggle, status lamps). Update `shell.ts` to use the new `grid-template-columns: 1fr 360px` layout. Stub `drawer.ts` and `threads.ts` as empty divs so the layout can be inspected before content fills in.
+
+Visual check: dashboard now has the bridge header + a 360px right column placeholder.
+
+### T3 — Repo grid in center pane
+
+Build `repoCards.ts`. For each repo in `lane.repo_states`, render a card showing: branch name, dirty count, actionable count (from `review_comments` joined to repo), PR link, path. Replace the current "Branches" card with this grid.
+
+Data sources: existing `lane` (already cached in DashboardPanel), `comments` (already cached). New computation: per-repo `actionable_count = comments.repos[repo].comments.length`.
+
+### T4 — Threads list in center pane
+
+Build `threads.ts`. Render unresolved comments as cards: repo tag, file:line link (clickable → `vscode.open`), author, age, body, 4 action buttons (Jump / Reply / Done / Defer). For v1, "Reply" / "Done" / "Defer" are stubs that show a toast — wired up to backends in T8 alongside drawer actions.
+
+Use the existing `comments` data already in cache. Sort by repo, then by age.
+
+### T5 — Right rail: summary table
+
+Build the 7-row state summary in `drawer.ts`. Data sources:
+- STATE: `feature_state(feature).state` (use existing client.featureState)
+- SLOT: derived from worktree presence (canonical = no worktree path; warm = has worktree)
+- DIRTY: sum of `lane.repo_states[*].changed_file_count`
+- UNPUSHED: sum of `lane.repo_states[*].ahead`
+- PRs: count of `status.repos[*].pr` non-null
+- ACTIONABLE: sum of `comments.repos[*].comments.length`
+- PREFLIGHT: from `lastPreflight` if set, else "—"
+
+All values render from cached data — no extra fetches.
+
+### T6 — Right rail: action groups (static layout)
+
+Build the 5 action groups in `drawer.ts` as static HTML — every action is a clickable div with `data-action="<message-type>"`. No wiring yet — clicking does nothing. Recommended action (★) gets the `recommended` class.
+
+Visual check at this point: drawer renders with all actions visible, all clickable but no-op.
+
+### T7 — Action wiring (per matrix above)
+
+For each row in the action wiring matrix, add the corresponding `case "<message-type>":` to `DashboardPanel.onDidReceiveMessage`. Most are 1-2 lines (delegate to existing client method + invalidate cache + refresh).
+
+The interesting handlers:
+- **commitAndPush** — show input box for message, then sequential `commit(msg)` → `push()`, surface combined per-repo summary in a toast.
+- **draftReplies** — call `draft_replies`, render results in a quick-pick that lets the user copy each draft to clipboard. (Posting via `gh` is out of scope for v1.)
+- **deferAll** — write to `.canopy/state/deferred.json`; refresh hides the threads section if `deferred_until > now`.
+- **showResolvedThreads** — toggle a class on the threads section that reveals the secondary `likely_resolved` list. Data already in `comments` cache.
+
+Each action that mutates state calls `forceRefresh()` on the panel afterwards (existing method) so the summary table reflects the change.
+
+### T8 — Recommended-action logic
+
+Surface the ★ on the Review group's first action when `actionable_count > 0`. Add similar logic for "Run preflight" when `dirty_count > 0` and no recent preflight, and "Commit + push" when `dirty_count == 0 && unpushed > 0`. Only one ★ at a time — the most-blocking action wins.
+
+### T9 — Theme parity
+
+Extract the navy palette into `themes.css` as CSS variables. Add the minimal palette as a `[data-theme="minimal"]` selector. Reuse the existing theme-name reader (`readThemeName()` from cockpitPanel.ts).
+
+### T10 — Build, package, install, smoke test
+
+Run through the action checklist manually. Each action should either: succeed and refresh the summary, or fail with a useful toast. No silent failures.
+
+### T11 — Docs
+
+Update `vscode-extension/README.md` (if present) with the new dashboard screenshot. Update `~/.claude/skills/using-canopy/SKILL.md` if any new tools were added (commit / push / draft_replies / etc.).
+
+---
+
+## Performance + caching
+
+The cache + progressive rendering work from Wave 7 phase I stays. Specifically:
+- Per-feature cache (`Map<feature, CacheEntry>`) survives panel close.
+- Three refresh modes: `refresh()`, `forceRefresh()`, `revalidate()` — semantics unchanged.
+- Section-by-section postMessage updates as fetches resolve.
+- The new sections (repo cards, threads, drawer) all source from existing cached data, so they don't add fetches — they just render more of what's already there.
+
+What does change:
+- The summary table needs `feature_state(feature).state` which isn't cached today. Add it as a 6th cached field on `CacheEntry` and a 6th fetch in `refresh()`.
+- The "actionable count" per repo is a derived value computed from `comments` — compute on render, no caching needed.
+
+---
+
+## Edge cases to remember
+
+- **No feature in canonical slot.** The "Hibernate" and "Move to a worktree" actions need a target — surface as disabled (with tooltip) when slot context is missing.
+- **GitHub MCP not configured.** The threads list shows "Review unavailable — configure GitHub MCP in `.canopy/mcps.json`" (matches today's behavior). Drawer's Review group greys out.
+- **Linear not linked.** Re-link Linear button stays enabled (it's the entry point); other Linear-dependent actions stay neutral.
+- **Single-repo features.** Repo grid collapses to one card. Drawer "Remove repo from lane" disables (can't remove the only repo).
+- **First-time `Commit + push` with no upstream.** The Wave 2.3 plan covers `BlockerError(code='no_upstream')` with a fix-action that retries with `--set-upstream`. The drawer's handler reads the BlockerError, prompts the user "Set upstream and retry?", and re-issues with `--set-upstream` on yes.
+- **Themes mid-session.** Theme toggle in the bridge re-renders the entire shell (no partial CSS swap). Cheap because cache hits keep all data warm.
+
+---
+
+## Out of scope
+
+- **Posting drafted replies** to GitHub. v1 surfaces drafts; user pastes. Add a "Post all" button in a Wave 4.1 once `draft_replies` is in active use.
+- **Cap-reached modal** for Slot actions. Already exists in `cockpitPanel.ts` (Wave 2.9 phase D); re-use that modal renderer when "Move to a worktree" hits the cap. Don't rebuild.
+- **Conflict-resolution UX** during sync/rebase. The action drawer fires `commit/push/sync`; resolving conflicts happens in the editor as today. Future plan if friction warrants.
+- **Customizable action set.** Actions are hard-coded per the mockup. No per-user reordering / hiding in v1.
+
+---
+
+## Rollout
+
+Bump extension to `0.5.0`. The new dashboard is a visible UX change — list it as the headline in the changelog. The previous single-column dashboard's behavior is fully preserved by the new center pane, plus the right rail is additive — so no user feature regresses.
+
+If the new layout doesn't fit a user's window (very narrow editor), the 360px drawer drops below the center pane via `@media (max-width: 1024px)` (single-column stack). Test this responsive case before declaring done.

--- a/docs/plans/archive/wave-2-3-commit-push.md
+++ b/docs/plans/archive/wave-2-3-commit-push.md
@@ -1,3 +1,10 @@
+---
+status: shipped
+priority: -
+effort: (shipped)
+depends_on: []
+---
+
 # Wave 2.3 — `commit` + `push` as canonical-feature primitives
 
 ## Mental model

--- a/docs/plans/archive/wave-2-3-commit-push.md
+++ b/docs/plans/archive/wave-2-3-commit-push.md
@@ -1,0 +1,156 @@
+# Wave 2.3 — `commit` + `push` as canonical-feature primitives
+
+## Mental model
+
+After Wave 2.9, the **canonical feature** is "what's checked out in main and what the user is focused on." Every CLI / MCP operation has a sensible default: when the user says `canopy commit -m "fix"`, they mean "commit across all repos in the canonical feature, scoped to its branches." Same for push.
+
+`commit` and `push` are the two primitives that were queued in Wave 2.3 but never landed. They're orthogonal to switch — commit doesn't change branches, push doesn't change branches — but they read from the same canonical-slot model so they don't need explicit `--feature` arguments.
+
+The mental model is a parallel rebase of `git`:
+
+| Single-repo git | Canopy multi-repo |
+|---|---|
+| `git commit -am "msg"` | `canopy commit -m "msg"` (all repos in canonical feature, all dirty + tracked) |
+| `git commit -m "msg" -- path/foo` | `canopy commit -m "msg" --repo foo --paths src/x.py` (filter to one repo, optional path scope) |
+| `git push` | `canopy push` (all repos in canonical feature, current branch each) |
+| `git push -u origin HEAD` | `canopy push --set-upstream` (first push for the feature branch) |
+
+**Implicit feature scope.** No `--feature` argument by default. Read `active_feature.json` → use that. Explicit `--feature X` overrides for non-canonical features (rare).
+
+**Multi-repo atomicity.** Per-repo failure rolls back nothing — git commits are local; they're already "atomic per repo." The user gets a structured per-repo result. If 2 of 3 repos commit and 1 fails on hooks, they see exactly that.
+
+---
+
+## Behavioral spec
+
+### `commit`
+
+`canopy commit -m <msg> [--feature X] [--repo R ...] [--paths P ...] [--no-hooks] [--amend]`
+
+| Pre-condition (per repo in scope) | Behavior |
+|---|---|
+| Repo is on the feature's expected branch (per `lane.branches`) | Stage `--paths` if given, else `git add -u` (all tracked changes); run pre-commit hooks; `git commit -m <msg>`. Returns `{repo, status: "ok", sha, files_changed}`. |
+| Repo is on a different branch than expected | `BlockerError(code='wrong_branch', expected: <feature-branch>, actual: <current-branch>, fix_actions: [switch(feature) or commit(--feature=<actual-feature>)])`. |
+| Repo has nothing to commit | `{repo, status: "nothing", reason: "no changes"}`. Not a failure. |
+| Pre-commit hook failed (and `--no-hooks` not passed) | `{repo, status: "hooks_failed", hook_output: <tail>}`. Stops here for this repo; other repos continue. |
+| Repo is in a worktree (warm feature) | Same logic; commit happens in the worktree dir. |
+| `--amend` and HEAD has nothing to amend (e.g. just-cloned) | Reject with `BlockerError(code='nothing_to_amend')`. |
+
+**Returns:** `{ feature, results: { <repo>: {status, sha?, files_changed?, reason?, hook_output?} } }`. Same shape as existing `sync` result.
+
+### `push`
+
+`canopy push [--feature X] [--repo R ...] [--set-upstream] [--force-with-lease] [--dry-run]`
+
+| Pre-condition (per repo in scope) | Behavior |
+|---|---|
+| Branch has upstream + nothing to push | `{repo, status: "up_to_date"}` |
+| Branch has upstream + commits to push | `git push` → `{repo, status: "ok", pushed_count: N, ref: "origin/<branch>"}` |
+| Branch has no upstream + `--set-upstream` passed | `git push --set-upstream origin <branch>` → `{repo, status: "ok", set_upstream: true}` |
+| Branch has no upstream + `--set-upstream` NOT passed | `BlockerError(code='no_upstream', repo, branch, fix_action: 'push --set-upstream')`. The fix-action carries the exact same args + `--set-upstream` so the agent can retry mechanically. |
+| Push rejected (non-fast-forward, no `--force-with-lease`) | `{repo, status: "rejected", reason: <git stderr tail>}`. Don't auto-force. |
+| Push rejected, `--force-with-lease` passed | `git push --force-with-lease` |
+
+`--dry-run` enumerates what *would* happen per repo without executing.
+
+**Returns:** `{ feature, results: { <repo>: {status, pushed_count?, ref?, reason?, set_upstream?} } }`.
+
+---
+
+## State model changes
+
+None. Both operations are read-only against `features.json` / `active_feature.json` and write only to git. They don't update any canopy state files.
+
+---
+
+## Command surface changes
+
+| Today | After Wave 2.3 |
+|---|---|
+| `canopy commit` (does not exist) | New CLI command + MCP tool. |
+| `canopy push` (does not exist) | New CLI command + MCP tool. |
+| `canopy preflight` | Unchanged. Preflight stages + runs hooks but never commits — used as a dry-run before `commit`. |
+| `canopy sync` | Unchanged. Sync rebases against default branch; commit/push are orthogonal. |
+
+---
+
+## Files to touch
+
+### New
+
+- `src/canopy/actions/commit.py` — orchestrator. Resolves canonical/explicit feature → list of (repo, branch, worktree_path) → fan out per-repo `_commit_one(repo, branch, ...)`.
+- `src/canopy/actions/push.py` — orchestrator. Same shape.
+- `tests/test_commit.py` — table-driven cases per row of the commit pre-condition matrix above.
+- `tests/test_push.py` — table-driven cases per row of the push matrix above.
+
+### Modified
+
+- `src/canopy/git/repo.py` — add `commit(repo_path, message, paths=None, amend=False, no_hooks=False)` and `push(repo_path, set_upstream=False, force_with_lease=False, dry_run=False)`. These are the only modules calling `subprocess.run(["git", ...])` per project convention; orchestrators MUST go through here.
+- `src/canopy/cli/main.py` — `cmd_commit(args)`, `cmd_push(args)`. Dispatch in `commands` dict. Add subparsers (mirror existing patterns from `cmd_sync`).
+- `src/canopy/mcp/server.py` — register `@mcp.tool()` wrappers for both: `commit(message, feature=None, repos=None, paths=None, no_hooks=False, amend=False)` and `push(feature=None, repos=None, set_upstream=False, force_with_lease=False, dry_run=False)`.
+- `docs/commands.md` — add `commit` + `push` sections.
+- `docs/agents.md` — add commit/push to "Common multi-repo operations".
+- `~/.claude/skills/using-canopy/SKILL.md` and `src/canopy/agent_setup/skill.md` — flag both as canonical-aware. The agent should use them in preference to `canopy run -- git commit/push`.
+
+---
+
+## Tasks (rough sequence)
+
+### T1 — `git/repo.py` primitives
+
+Implement `commit()` and `push()` as thin wrappers around `subprocess.run` that return structured result dicts (sha, files_changed, pushed_count, etc.) and surface stderr on failure. Hooks run by default; `--no-verify` only when `no_hooks=True`. **Never** pass `--no-gpg-sign` or skip signing — leave sign behavior to the user's git config.
+
+Tests in `tests/test_repo.py` (existing file): cover happy path + nothing-to-commit + hook failure + no-upstream + force-with-lease.
+
+### T2 — `actions/commit.py` orchestrator
+
+Resolve feature scope (canonical via `active_feature.json` if no `--feature` else explicit). Resolve per-repo paths via the existing `lane.repos` + worktree-aware path resolution (same logic `feature_state` uses — see `actions/feature_state.py`). Fan out per-repo with `concurrent.futures.ThreadPoolExecutor` (existing parallelism pattern from `actions/switch.py`). Aggregate into the structured return.
+
+`BlockerError(code='wrong_branch', ...)` raised before any per-repo work fires if any repo's current branch doesn't match `lane.branches[repo]`.
+
+Tests: workspace_with_feature fixture + variants for each pre-condition row.
+
+### T3 — `actions/push.py` orchestrator
+
+Same shape as commit. The interesting cases are no-upstream (returns BlockerError with the exact retry args) and rejected (don't auto-force). `--dry-run` populates the structured return without firing pushes.
+
+Tests: same fixture + variants per row.
+
+### T4 — CLI + MCP wrappers
+
+Thin wrappers over the actions. CLI prints a per-repo summary table on stdout; `--json` returns the structured dict. MCP tool returns `result.to_dict()` directly.
+
+### T5 — Docs + skill updates
+
+`docs/commands.md` gets two sections with example invocations. `docs/agents.md` adds a "Commit / push from the agent" section. Both skills (user-installed + bundled) get the new tools listed in the "preferred over" table.
+
+### T6 — Composition test
+
+Integration test: workspace_with_feature → modify file in both repos → `canopy commit -m "test"` → assert commits present in both → `canopy push --set-upstream` → assert upstream set. Uses real temp git repos (existing `tests/conftest.py` fixture pattern).
+
+---
+
+## Edge cases to remember
+
+- **Pre-commit hooks that modify files.** If a hook re-formats the staged file, the commit may include unexpected diffs. Document this; don't try to detect / re-stage. Match git's native behavior.
+- **Detached HEAD.** Treat as `wrong_branch` with `expected: <feature-branch>, actual: 'HEAD detached at <sha>'`. Fix action: checkout the feature branch.
+- **Empty message.** Reject at CLI parse (argparse) before calling action.
+- **Feature with worktree per repo.** Resolve via `lane.repo_states[repo].worktree_path` (when warm) or `lane.repo_states[repo].abs_path` (when canonical). The same path-resolution helper used by `feature_state` and `feature_diff` should be factored out if not already.
+- **Commit signing.** If user has `commit.gpgsign=true` and gpg is broken, commit fails with the gpg error in stderr. Surface verbatim — don't try to disable signing.
+
+---
+
+## Out of scope
+
+- `commit --interactive` / patch-mode staging. Use raw `git -C <repo> add -p` for that.
+- Per-repo commit messages. One message, all repos. Cross-repo coupling is the point.
+- Squash / rebase / interactive history rewriting. Use `git` directly for those.
+- Automatic conflict resolution on push reject. User runs `canopy sync` (rebase) then re-pushes.
+
+---
+
+## After this lands
+
+- The action drawer's "Commit + push" button can be wired to call `commit` then `push` in sequence (or as a composite — see Wave 2.4 plan).
+- The CLI workflow becomes: `canopy preflight` → review hooks output → `canopy commit -m "msg"` → `canopy push`. Three commands; no `--feature` needed when the canonical slot is set.
+- The dashboard's "Run preflight" button retains its current role (stage + run hooks, no commit). Adding "Commit + push" as a sibling action makes the workflow complete inside one panel.

--- a/docs/plans/augments.md
+++ b/docs/plans/augments.md
@@ -1,3 +1,10 @@
+---
+status: queued
+priority: P1
+effort: ~2-3d
+depends_on: ["doctor.md"]
+---
+
 # Augment skill — per-workspace customization
 
 ## Why

--- a/docs/plans/augments.md
+++ b/docs/plans/augments.md
@@ -1,0 +1,166 @@
+# Augment skill — per-workspace customization
+
+## Why
+
+Canopy operations that vary by team/codebase — which preflight command runs, which test command runs, which authors count as bots — are currently hardcoded. `pre-commit run --all-files` is the only preflight; `author_type == "Bot"` substring is the only bot detector; there's no `canopy test` command yet.
+
+Real workspaces want per-workspace customization. Examples:
+- "This monorepo uses `ruff format && pyright` for preflight, not `pre-commit run`."
+- "Track CodeRabbit + Korbit as bot reviewers; ignore Copilot's nits."
+- "The frontend repo's tests are `pnpm test:unit`; the backend is `pytest tests/fast`."
+
+This plan adds a `[augments]` workspace-level config table plus per-repo overrides, a new `augment-canopy` skill that teaches the agent how to mutate the config, and the wiring needed for the first consumer (preflight).
+
+## Goal
+
+Per-workspace customization for canopy operations, stored in `canopy.toml` and set via the `augment-canopy` skill. v1 covers preflight; review_bots and test_cmd are declared in the schema and consumed where ready (review_bots is consumed by N2 bot-comment tracking).
+
+## Non-goals
+
+- Custom commit-message templates, branch-naming conventions, etc. Future augments; not v1.
+- Per-feature augments (different preflight for different features in same workspace). Workspace + per-repo is enough complexity for v1.
+- Reachable via `canopy config get/set augments.preflight_cmd` — `cmd_config` is flat-only; nested-key support is a separate refactor. The augment-canopy skill writes TOML directly in v1.
+- Augment validation (catching typos like `preflight_cmmd` silently being ignored by the lenient parser). Add `canopy doctor --check-augments` later, or fold into doctor.
+
+## Schema
+
+Two-tier: workspace defaults + per-repo override.
+
+```toml
+[augments]
+preflight_cmd = "make check"             # workspace default for all repos
+test_cmd = "pytest"
+review_bots = ["coderabbit", "korbit"]   # case-insensitive author substring match (consumed by N2)
+
+[[repos]]
+name = "api"
+path = "./api"
+augments = { preflight_cmd = "uv run pytest tests/fast" }   # per-repo override
+```
+
+**Resolution helper** (new module):
+
+```python
+# src/canopy/actions/augments.py
+
+def repo_augments(workspace: WorkspaceConfig, repo_name: str) -> dict[str, Any]:
+    """Merge workspace [augments] defaults with per-repo augments override.
+    Per-repo wins on key collision."""
+    workspace_augments = workspace.augments or {}
+    repo_config = next((r for r in workspace.repos if r.name == repo_name), None)
+    repo_augments = (repo_config.augments if repo_config else {}) or {}
+    return {**workspace_augments, **repo_augments}
+
+def bot_authors(workspace: WorkspaceConfig) -> list[str]:
+    """Return the configured list of bot-author substrings (lowercased)."""
+    augments = workspace.augments or {}
+    return [s.lower() for s in augments.get("review_bots", [])]
+```
+
+The `cmd_config` CLI is flat-only and the augment-canopy skill (separate concern) handles config mutation by writing TOML directly. Defer `canopy config augments.preflight_cmd "..."` until augments stabilize.
+
+## New skill: `augment-canopy`
+
+Lives at `src/canopy/agent_setup/skills/augment-canopy/SKILL.md`. Loaded only when the user is actively customizing — the existing `using-canopy` skill covers normal operations.
+
+The skill teaches the agent:
+- **When to suggest customization.** User says "use X for preflight", "track these specific bots", "this repo uses Y for tests" — agent recognizes the pattern and offers to update canopy.toml.
+- **The TOML schema.** Workspace `[augments]` vs per-repo `[[repos]] augments = {...}`. Per-repo wins on collision.
+- **How to mutate canopy.toml safely.** Read → parse with `tomli`/`tomllib` → modify → atomic write (`os.rename` from a temp file in the same directory).
+- **Augment changes are picked up on next operation.** No canopy restart required; each operation re-reads canopy.toml.
+
+The skill includes a worked example: user says "this workspace uses ruff for preflight" → agent reads canopy.toml → adds `preflight_cmd = "ruff check ."` to `[augments]` → atomic write → confirms with the user.
+
+## Wiring change (v1 consumer: preflight)
+
+`src/canopy/integrations/precommit.py`:
+
+```python
+def run_precommit(repo_path: Path, repo_config: RepoConfig | None = None) -> dict:
+    """Run the configured preflight command for this repo, falling back to auto-detection."""
+    augments = repo_augments(workspace, repo_config.name) if repo_config else {}
+    if "preflight_cmd" in augments:
+        return _run_custom_preflight(repo_path, augments["preflight_cmd"])
+    # existing auto-detection: detect_precommit() → _run_framework() or _run_git_hook()
+    ...
+```
+
+Three call sites pass `repo_config`:
+- `src/canopy/features/coordinator.py:1035` (review_prep path)
+- `src/canopy/mcp/server.py:563` (preflight MCP tool)
+- `src/canopy/cli/main.py:1126` (cmd_preflight)
+
+When `repo_config.augments.preflight_cmd` is set, the override runs; otherwise existing auto-detection (pre-commit framework or git hook) applies.
+
+## Skill packaging refactor
+
+The existing skill installer is single-skill. Generalize to support multiple skills:
+
+```
+src/canopy/agent_setup/
+├── __init__.py
+└── skills/
+    ├── using-canopy/SKILL.md       # existing, moved from agent_setup/skill.md
+    └── augment-canopy/SKILL.md     # new in this plan
+```
+
+```python
+def install_skill(name: str = "using-canopy", *, reinstall: bool = False) -> dict:
+    src = _SKILLS_DIR / name / "SKILL.md"
+    dst = _USER_SKILLS_DIR / name / "SKILL.md"
+    # ... existing idempotency logic, generalized over name
+```
+
+```python
+def setup_agent(workspace_root, *, skills: tuple[str, ...] = ("using-canopy",), do_mcp=True, reinstall=False) -> dict:
+    ...
+```
+
+Doctor's diagnostic categories iterate the same skill list to detect missing/stale skills.
+
+## Files to touch
+
+- `src/canopy/workspace/config.py` — extend `WorkspaceConfig` with `augments: dict[str, Any]`, extend `RepoConfig` with `augments: dict[str, str]`, update `_parse_config()` to populate both
+- **New:** `src/canopy/actions/augments.py` — `repo_augments()` resolver, `bot_authors()` helper
+- `src/canopy/integrations/precommit.py` — `run_precommit` signature change to accept optional `repo_config`
+- `src/canopy/features/coordinator.py`, `src/canopy/mcp/server.py`, `src/canopy/cli/main.py` — three call-site updates
+- `src/canopy/agent_setup/__init__.py` — skill packaging refactor; `install_skill` + `setup_agent` generalization
+- **Move:** `src/canopy/agent_setup/skill.md` → `src/canopy/agent_setup/skills/using-canopy/SKILL.md`
+- **New:** `src/canopy/agent_setup/skills/augment-canopy/SKILL.md` (~3-4 KB content, includes worked example of "user says X → agent edits canopy.toml")
+- `tests/test_augments.py` (new), `tests/test_config.py` (extended), `tests/test_precommit.py` (extended)
+- `docs/workspace.md` — document `[augments]` block + per-repo override
+- `docs/agents.md` — reference the augment skill
+
+## Implementation order
+
+1. Extend `RepoConfig` + `WorkspaceConfig` dataclasses + parser. Tests pass with empty defaults (backward-compatible).
+2. New `repo_augments()` resolver in `actions/augments.py`. Pure function; unit-tested.
+3. Extend `run_precommit()` signature with optional `repo_config`. Update three call sites. Existing tests pass with default `None` (preserves auto-detection behavior).
+4. Reorganize skill packaging. Update `cmd_init` and `cmd_setup_agent` callers.
+5. Write `augment-canopy/SKILL.md`.
+6. Add `canopy setup-agent --skill augment-canopy` flag for opt-in install.
+
+## Verification
+
+- Unit: resolver merges workspace + per-repo correctly; per-repo wins on collision; missing keys return `None`/empty.
+- Unit: `run_precommit` with custom `preflight_cmd` runs the override; with `None`, auto-detect still works.
+- Integration: workspace with `augments.preflight_cmd = "echo ok && exit 0"` → `canopy preflight` returns success.
+- Manual: agent reads "this workspace uses ruff for preflight" from a user message → invokes `augment-canopy` skill instructions → canopy.toml updated → `canopy preflight` runs `ruff check .`.
+
+## Edge cases
+
+- **Symlinked canopy.toml**: read via `Path.resolve()`, write to the resolved path's directory.
+- **Concurrent agent edits**: agents may run in parallel and both try to mutate canopy.toml. Atomic-write via `os.rename` from a temp file in the same directory minimizes race window. If the file changes between read and write, retry once; on second failure, return `BlockerError(code='canopy_toml_concurrent_write')`.
+- **Invalid command in `preflight_cmd`**: surfaces as a non-zero exit code from `_run_custom_preflight`. Captured in the result dict; doesn't crash canopy.
+- **Old canopy reading new schema**: lenient parser silently ignores unknown keys. Old canopy versions with new canopy.toml work unchanged (just don't honor the augments).
+
+## Effort
+
+~2-3 days. Most of the work is the schema additions + resolver + three call-site updates + the new skill content.
+
+## After this lands
+
+- N2 (bot-comment tracking) reads `bot_authors(workspace)` from this resolver.
+- The `using-canopy` skill picks up minor updates to teach the agent to *suggest* the augment-canopy skill at the right moments.
+- Foundation for future augments (commit message templates, branch-naming conventions, etc.) — same `[augments]` table grows.
+- Provider-injection pattern (architecture doc, providers-arch.md) is conceptually similar; augments + providers form canopy's two-pronged customization story (augments = behavioral overrides, providers = swappable integrations).

--- a/docs/plans/bot-tracking.md
+++ b/docs/plans/bot-tracking.md
@@ -1,0 +1,137 @@
+# Bot-comment tracking + `commit --address`
+
+## Why
+
+PRs collect comments from multiple bots (CodeRabbit, Korbit, Cubic, Copilot) alongside human reviewers. Today canopy treats them all as one undifferentiated "review comments" stream — agents can't quickly answer "are all the bot nits resolved?" or "which commit addressed bot comment #123456?" without re-deriving from PR history.
+
+The user's framing in the dogfood transcript: *"bot comments should be fixed and committed one by one addressing the comment title for tracking. A dev can ask: are all the bot comments in this set of PRs resolved?"*
+
+This plan adds a distinct workflow concern: track per-comment "addressed by which commit," provide a rollup ("all bot comments resolved?"), and add a `commit --address <comment-id>` flag with auto-formatted commit messages that include the comment URL for downstream tracing.
+
+## Goal
+
+Treat bot review comments as a distinct workflow concern with structured persistence + a focused command. Specifically:
+
+- Distinguish bot vs human review threads using the existing `author_type == "Bot"` signal + the configurable `review_bots` augment from N3 (per-workspace whitelist of substrings).
+- Persist per-comment resolution state in `<workspace>/.canopy/state/bot_resolutions.json`.
+- Add `canopy commit --address <comment-id> -m "..."` that auto-formats the commit message with the bot comment title + URL and records the resolution.
+- Add `canopy bot-status [--feature <X>]` rollup CLI + MCP tool.
+- Insert `awaiting_bot_resolution` state in the state machine (per architectural decision: do not gate `approved`).
+
+## Non-goals
+
+- Auto-posting replies to bot comments (deferred Wave 4 — `draft_replies` plan).
+- Inferring resolution from commit content/diff. v1 requires explicit `--address <comment-id>` to claim resolution.
+- Unifying with human-comment workflows. Humans request changes; canopy already handles that via `needs_work`. Bots produce nits; this plan handles them as a distinct, less-blocking signal.
+
+## State machine placement
+
+Insert `awaiting_bot_resolution` between `awaiting_review` and `approved`. Do **not** gate `approved` — human approval is the merge gate; bot nits are a side-channel.
+
+```
+drifted > needs_work (human) > in_progress > ready_to_commit
+       > ready_to_push > awaiting_bot_resolution > awaiting_review
+       > approved > no_prs
+```
+
+**Trigger** for `awaiting_bot_resolution` per repo:
+- (a) no human `CHANGES_REQUESTED` review_decision
+- (b) no actionable human threads (`actionable_human_count == 0`)
+- (c) ≥1 actionable bot thread (`actionable_bot_count > 0`)
+- (d) PR not yet `APPROVED`
+
+If approved + bot threads still open: state stays `approved`; surface "address bot comments" as a *secondary* CTA in `next_actions` (not gating). Bot comments don't block merge.
+
+## Data model changes
+
+- `src/canopy/integrations/github.py:_normalize_comments` (line 537): include `id` field — `"id": c.get("id")`. Backward-compat (consumers ignoring the field continue working).
+- **New persistent state:** `<workspace>/.canopy/state/bot_resolutions.json`. Append-only mapping `{<comment_id>: {feature, repo, commit_sha, addressed_at, comment_title}}`. Written by `commit --address`. Read by `bot_comments_status` and by `feature_state` to compute `actionable_bot_count` (subtracting resolved comments).
+- `src/canopy/actions/feature_state.py:_per_repo_facts`: split `actionable_count` into `actionable_human_count` + `actionable_bot_count`. Bot determined by `author_type == "Bot"` AND author matching `bot_authors(workspace)` (uses N3's `review_bots` augment via the `bot_authors()` helper from `actions/augments.py`).
+- `src/canopy/actions/feature_state.py:_decide_state`: insert `awaiting_bot_resolution` per the trigger rules above.
+
+## New CLI / MCP surface
+
+### `canopy commit --address <comment-id> [-m "..."]`
+
+- Resolves `<comment-id>` against the feature's actionable bot threads (via `_per_repo_facts`).
+- Looks up the comment's `body` (truncated first sentence as the title) and `url`.
+- Auto-formats commit message: `<user message>\n\nAddresses bot comment: "<title-fragment>" (<url>)`. If no `--message` is given, uses just the auto-line.
+- On commit success, appends to `bot_resolutions.json`.
+- Returns the existing per-repo result dict with an extra `addressed_comment_id` field.
+
+### `canopy bot-status [--feature <X>] [--unresolved-only]`
+
+- Per-PR rollup of bot comments — total, resolved, unresolved.
+- `--unresolved-only` lists just the open ones with comment URLs.
+- `--json` returns the structured dict (used by the agent and the dashboard).
+
+### MCP tool: `bot_comments_status(feature: str | None = None)`
+
+Returns:
+```python
+{
+  "feature": "sin-6-cache-stats",
+  "repos": {
+    "test-api": {
+      "pr_number": 142,
+      "total_bot_comments": 4,
+      "resolved": 2,
+      "unresolved": 2,
+      "threads": [
+        {"id": 123456, "author": "coderabbit", "url": "...", "resolved": True, "resolved_by_commit": "abc123de"},
+        ...
+      ]
+    }
+  },
+  "all_resolved": False,
+}
+```
+
+## Files to touch
+
+- `src/canopy/integrations/github.py` (line 537) — add `"id": c.get("id")` to normalized comment dict
+- `src/canopy/actions/feature_state.py` (lines 133–217 + 318–327) — split actionable counts; add `awaiting_bot_resolution` state
+- `src/canopy/actions/commit.py` (line 165) — add `address: str | None = None` param; pre-process message; write to `bot_resolutions.json` on success
+- **New:** `src/canopy/actions/bot_resolutions.py` — `record_resolution(workspace, comment_id, feature, repo, sha, title)`; `load_resolutions(workspace)`; `is_resolved(workspace, comment_id) -> bool`
+- **New:** `src/canopy/actions/bot_status.py` — `bot_comments_status(workspace, feature) -> dict` rollup
+- `src/canopy/cli/main.py` — `cmd_bot_status` + subparser; extend `cmd_commit` argparse with `--address`
+- `src/canopy/mcp/server.py` — register `bot_comments_status` MCP tool
+- `tests/test_bot_resolutions.py` (new) — record + load + persist round-trip
+- `tests/test_bot_status.py` (new) — rollup correctness with mixed resolved/unresolved fixtures
+- `tests/test_commit.py` (extended) — extend with `--address` cases (resolves comment id, message format, side-effect to `bot_resolutions.json`)
+- `tests/test_feature_state.py` (extended) — extend with cases that exercise `awaiting_bot_resolution`
+
+## Implementation order
+
+1. Add `id` to normalized comments (`integrations/github.py:537`). Update fixtures in `tests/test_review_filter.py` and `tests/test_reads.py`.
+2. New `actions/bot_resolutions.py` module — file IO for `.canopy/state/bot_resolutions.json`. Pure functions; unit-tested.
+3. Split actionable counts in `_per_repo_facts`. Use the `bot_authors()` helper from N3 (or fallback to `author_type == "Bot"` if N3 not yet shipped).
+4. Add `awaiting_bot_resolution` state in `_decide_state` per the trigger rules.
+5. Extend `commit()` action with `--address` parameter. Resolve comment ID to title/url. Format message. Record resolution.
+6. Build `bot_comments_status` rollup. CLI + MCP wiring.
+7. `next_actions` updates: when state is `awaiting_bot_resolution`, surface `canopy commit --address <id> -m "..."` for each unresolved thread.
+
+## Verification
+
+- Unit: `bot_resolutions.py` round-trip; `bot_status.py` rollup with mixed resolved/unresolved fixtures.
+- Unit: `_decide_state` returns `awaiting_bot_resolution` for the four trigger conditions; returns `approved` if also approved (per the architectural refinement).
+- Integration: `workspace_with_feature` fixture + a fake bot comment fixture → `commit --address <id> -m "fix"` → assert `bot_resolutions.json` has the entry → `bot_comments_status` returns `all_resolved: true`.
+- Manual: real PR with bot comments. `canopy bot-status` shows them; `canopy commit --address <id> -m "..."` produces a commit whose message includes the bot comment URL; subsequent `bot-status` shows resolved.
+
+## Edge cases
+
+- **Comment ID resolution from URL.** Some agents will pass the GitHub URL instead of the numeric ID. Accept both; parse the URL and extract the comment ID.
+- **Comment that was deleted from GitHub.** `bot_comments_status` skips it from the unresolved list silently; the resolution log entry persists for history.
+- **`commit --address` when the comment isn't a bot comment.** Rejected with `BlockerError(code='not_a_bot_comment', ...)` — `--address` is bot-specific. Future: extend to human comments via a separate flag.
+- **Multiple `--address` on one commit.** v1 supports a single `--address`. Multi-address can be added later if needed (loop through and call `record_resolution` per id).
+- **Concurrent `commit --address` calls.** `bot_resolutions.json` writes use atomic rename (write to temp, rename). Concurrent writes are rare but safe.
+
+## Effort
+
+~3 days.
+
+## After this lands
+
+- The dashboard's "Address bot comments" CTA (action drawer plan) becomes wirable: click → quick-pick lists unresolved bot threads → click one → command palette opens with `canopy commit --address <id> -m "..."` prefilled.
+- Historian (next plan) consumes `bot_resolutions.json` + the temporal classifier output to render a "Resolutions log" section in the per-feature memory file.
+- The agent answer to "is this PR ready to merge?" becomes definitive: feature_state returns `approved` only when human-side is green; bot-resolution status is a separate, surface-able signal.

--- a/docs/plans/bot-tracking.md
+++ b/docs/plans/bot-tracking.md
@@ -1,3 +1,10 @@
+---
+status: queued
+priority: P1
+effort: ~3d
+depends_on: ["augments.md"]
+---
+
 # Bot-comment tracking + `commit --address`
 
 ## Why

--- a/docs/plans/ci-status.md
+++ b/docs/plans/ci-status.md
@@ -1,3 +1,10 @@
+---
+status: queued
+priority: P2
+effort: ~2d
+depends_on: ["bot-tracking.md"]
+---
+
 # CI status integration in `feature_state`
 
 ## Why

--- a/docs/plans/ci-status.md
+++ b/docs/plans/ci-status.md
@@ -1,0 +1,193 @@
+# CI status integration in `feature_state`
+
+## Why
+
+Today canopy's 8-state machine knows about PR review state (`changes_requested`, `approved`, etc.) but is blind to CI check runs. That makes `approved` a misleading terminal state when 2 of 3 GitHub Actions are red — the agent (or you) thinks the feature is ready to merge, runs `gh pr merge`, and discovers the gating problem post-hoc.
+
+The real "ready to merge" question is `approved && all_required_checks_passing && no_pending_checks`. Canopy's state machine should answer that.
+
+This plan adds CI status as a first-class field on `feature_state.repos[*].pr` and introduces a new `awaiting_ci` state that sits between `awaiting_review` and `approved`, so the lifecycle reads:
+
+```
+needs_work → in_progress → ready_to_commit → ready_to_push
+  → awaiting_review → awaiting_ci → approved → (merged via gh)
+```
+
+The agent reads `feature_state(feature).next_actions` and knows: ignore, address comments, run preflight, push, wait for review, *wait for CI*, merge.
+
+---
+
+## Behavioral spec
+
+### New field on `feature_state.repos[*].pr`
+
+```python
+{
+  "pr": {
+    "number": 142,
+    "url": "https://github.com/.../pull/142",
+    "state": "open",
+    "review_decision": "approved",        # existing
+    "ci_status": {                         # NEW
+      "status": "pending" | "passing" | "failing" | "no_checks",
+      "passed": 8,                         # count
+      "failing": 1,
+      "pending": 2,
+      "skipped": 0,
+      "required_failing": ["lint", ...],   # required checks that are failing (gating)
+      "required_pending": ["e2e-test"],    # required checks pending
+      "details_url": "https://...",        # GH checks tab
+    }
+  }
+}
+```
+
+`status` is the rolled-up answer: `passing` only when every required check passed and zero pending; `failing` when any required failed; `pending` when nothing failing but at least one required is pending; `no_checks` when the PR has no associated check runs.
+
+### State machine extension
+
+Insert `awaiting_ci` between `awaiting_review` and `approved`. Rules per repo:
+
+| review_decision | ci_status | Resulting state contribution |
+|---|---|---|
+| (none) | (any) | feed into `awaiting_review` (existing) |
+| `changes_requested` | (any) | `needs_work` (existing) |
+| `approved` | `passing` | `approved` |
+| `approved` | `pending` | `awaiting_ci` (NEW) |
+| `approved` | `failing` | `needs_work` (CI is a blocker — same intent as a request for changes) |
+| `approved` | `no_checks` | `approved` (no CI configured = trust review) |
+
+Multi-repo aggregation: feature-level state is the "least-ready" repo state in canonical lifecycle order. So if api is `approved` and ui is `awaiting_ci`, the feature is `awaiting_ci`.
+
+### `next_actions` updates
+
+When state is `awaiting_ci`, next_actions reads:
+
+```
+1. Wait for {required_pending} to complete (estimated <duration>)
+2. If a check is failing: investigate the failing check at <details_url>
+3. (Optional) Re-run failing checks via `gh pr checks --watch` or by pushing an empty commit
+```
+
+Action 1 surfaces only when nothing is failing yet. Action 2 surfaces when there's a failing required check.
+
+### CLI rendering
+
+`canopy state <feature>` and `canopy review <feature>` both gain a CI line per repo:
+
+```
+test-api    PR #142  approved  ci: 8 passed, 1 failing (lint), 2 pending
+                              ↗ https://github.com/acme/test-api/pull/142/checks
+```
+
+`canopy triage` rolls up: a feature in `awaiting_ci` with failing required checks gets surfaced near `changes_requested` (not at the bottom with `approved`).
+
+---
+
+## State model changes
+
+- New state enum value: `awaiting_ci`. Total states: 9 (was 8).
+- `feature_state.repos[*].pr.ci_status` field added (optional — old MCP clients still work, just don't see it).
+- `next_actions` array can include CI-driven entries.
+
+---
+
+## Command surface changes
+
+| Today | After |
+|---|---|
+| `canopy review <feature>` | Output adds CI line per PR. Field `ci_status` in `--json`. |
+| `canopy state <feature>` | New possible state `awaiting_ci`. |
+| `mcp__canopy__pr_checks(alias)` (does not exist) | New MCP tool returning the raw check-run list for a PR (useful when the rolled-up `ci_status` isn't enough — e.g., agent wants to look at one specific check's logs). |
+| `canopy triage` | Sort order accounts for `awaiting_ci` failing-required ahead of plain `approved`. |
+
+---
+
+## Files to touch
+
+### New
+
+- `src/canopy/integrations/github_checks.py` — wraps `gh pr checks --json` (or MCP `get_pr_checks` if configured). Returns the structured check-run list. Mirrors the existing pattern in `integrations/github.py` for review_status.
+- `tests/test_ci_status.py` — table-driven cases for each state-machine row above.
+
+### Modified
+
+- `src/canopy/integrations/github.py` — add `get_pr_checks(repo, pr_number)` helper returning the rolled-up `ci_status` dict + raw check list. Or split into `github_checks.py` if it's getting fat.
+- `src/canopy/actions/feature_state.py` — extend `_per_repo_facts` to call `get_pr_checks` per repo with an open PR, populate `ci_status`. Extend the state-resolution function to incorporate ci_status per the matrix above. Add `awaiting_ci` to the state enum + `next_actions` for it.
+- `src/canopy/actions/triage.py` — adjust priority sort to weight `awaiting_ci`-with-failures above `approved`.
+- `src/canopy/cli/main.py` — `cmd_review` and `cmd_state` render the new CI line.
+- `src/canopy/mcp/server.py` — register `pr_checks(alias)` tool (universal-alias resolved).
+- `docs/concepts.md` — update the state machine diagram + state list.
+- `docs/agents.md` — update review-loop recipe with `awaiting_ci` handling.
+- `docs/commands.md` — `state` and `review` sections show the CI rendering.
+
+---
+
+## Tasks (rough sequence)
+
+### T1 — `get_pr_checks` integration
+
+Wrap `gh pr checks <pr-number> --json name,state,bucket,conclusion,workflow,detailsUrl,startedAt`. Compute `ci_status` rollup from the raw list. Distinguish required vs informational checks via `gh api repos/.../branches/main/protection` (cached per workspace, refreshed lazily). Fallback when MCP `pull_request_checks` tool is configured: prefer that.
+
+Returns `(ci_status, raw_check_list)`.
+
+Tests: mock `gh` subprocess + happy / failing / pending / no-checks variants.
+
+### T2 — Extend `feature_state`
+
+`_per_repo_facts` calls `get_pr_checks` for each open PR. Populates `ci_status`. State-resolution function gets the new matrix branch.
+
+Tests: workspace_with_feature + variants per matrix row. Snapshot test the resulting `feature_state` JSON.
+
+### T3 — `awaiting_ci` state + `next_actions` text
+
+Add the enum value. Implement the next_actions builder for the new state — distinguishing "wait" (all required pending, none failing) from "investigate" (at least one required failing).
+
+Tests: snapshot the `next_actions` strings for representative inputs.
+
+### T4 — CLI rendering
+
+Extend `cmd_review` and `cmd_state` output. Add the per-repo CI line. Honor `--json` (already passes through structured).
+
+### T5 — Triage priority
+
+`actions/triage.py` priority weights: `changes_requested` > `awaiting_ci (failing required)` > `awaiting_ci (pending)` > `awaiting_review` > `approved`. Update sort.
+
+Tests: triage fixture with mixed-state features asserts the order.
+
+### T6 — `pr_checks` MCP tool
+
+Universal-alias resolved (existing pattern). Returns the raw check list (the second value from `get_pr_checks`).
+
+### T7 — Docs + skills
+
+`docs/concepts.md` state diagram updated. `docs/agents.md` review recipe extended. `docs/commands.md` rendering examples. Both skill files note `awaiting_ci` and `pr_checks`.
+
+---
+
+## Edge cases to remember
+
+- **Repo with no GH Actions configured at all.** `gh pr checks` returns an empty list. Treat as `no_checks`, state contribution is `approved` (no CI to wait for).
+- **Required-checks list is empty (branch protection lax).** Same as no_checks for state-machine purposes; CI runs are informational.
+- **A check is rerunning.** Looks like `pending` from `gh pr checks`. Treated as pending. If the rerun was started by canopy, that's fine; if by the user, also fine.
+- **Stale PR with old check runs.** `gh pr checks` returns the latest run per check. No special handling.
+- **Privately-hosted GitHub.** `gh` honors `GH_HOST` / `GITHUB_HOST` env. Should work without code changes; doc the requirement.
+- **PR closed/merged before checks completed.** Closed PRs return checks but the state-machine ignores them — feature drops out of active triage.
+
+---
+
+## Out of scope
+
+- **Auto-merging when CI passes.** That's `gh pr merge --auto`'s job. Canopy reports state; merge is a human/agent action.
+- **Re-running failed checks.** Same — out of scope. User runs `gh run rerun` or `gh pr comment` with `/rerun`.
+- **CI provider abstraction.** v1 is GitHub Actions via `gh pr checks`. CircleCI / Buildkite / GitLab are future extensions; the abstraction would live in `integrations/ci.py` with provider-specific backends. Not v1.
+- **Required vs informational distinction precision.** v1 reads branch protection rules; teams that gate via CODEOWNERS or arbitrary GH Apps may need follow-up tuning.
+
+---
+
+## After this lands
+
+- The "approved" state actually means "ready to merge." No more "approved + 1 failing check" surprise at merge time.
+- Agents in the post-review loop can wait correctly for CI before claiming the feature is done.
+- `canopy triage` better reflects what's blocked vs what's ready — `awaiting_ci`-with-failures floats up; pure `approved` floats up too but is differentiated.
+- Pairs with the (future) `ship` MCP tool (Wave 2.4 plan): `ship` becomes safer because it knows whether to merge or wait.

--- a/docs/plans/cross-feature-conflicts.md
+++ b/docs/plans/cross-feature-conflicts.md
@@ -1,3 +1,10 @@
+---
+status: queued
+priority: P3
+effort: ~1-2d
+depends_on: []
+---
+
 # `canopy conflicts` — cross-feature file-overlap detection
 
 ## Why

--- a/docs/plans/cross-feature-conflicts.md
+++ b/docs/plans/cross-feature-conflicts.md
@@ -1,0 +1,171 @@
+# `canopy conflicts` — cross-feature file-overlap detection
+
+## Why
+
+Canopy treats features as independent. They are — at the git level. But two active features can touch the same file: `auth-flow` modifies `src/api/server.py` lines 40-60; `payment-flow` modifies the same file lines 50-80. Canopy doesn't notice. The first one merges; the second one rebases and discovers the conflict — at PR review time, when the user has already shipped a PR description and pinged a reviewer.
+
+`canopy conflicts` precomputes overlap. For each pair of active features, intersect their changed-files. Surface pairs whose intersection is non-empty so the user can resolve overlaps proactively (rebase one onto the other, or split the work) instead of discovering at merge time.
+
+This isn't critical infrastructure — most workspaces have low overlap probability — but it's a small, useful tool that turns an "oh shit" surprise into a 30-second proactive check.
+
+Lower-priority than `doctor` and CI status; written here for completeness.
+
+---
+
+## Behavioral spec
+
+`canopy conflicts [--feature <X>] [--with <Y>] [--include-cold]`
+
+Default: enumerate all *active* features (canonical + warm), pairwise compute file-overlap, return non-empty pairs.
+
+`--feature X` scopes to "what overlaps with feature X" — useful for the agent before opening a PR. `--with Y` further scopes to "specifically X vs Y."
+
+`--include-cold` extends the scan to cold features. By default cold features are ignored (their changes are still git-recorded but they're not actively rotating, so conflict probability with active work is lower-priority).
+
+### Per-pair output
+
+```python
+{
+  "feature_a": "auth-flow",
+  "feature_b": "payment-flow",
+  "overlap": {
+    "test-api": {
+      "files": ["src/api/server.py", "src/api/middleware.py"],
+      "lines_a_only": 24,         # lines changed by A but not B
+      "lines_b_only": 18,
+      "lines_both": 12,           # lines changed by BOTH (real conflict candidates)
+    },
+    "test-ui": {
+      "files": [],                # no overlap in this repo
+    }
+  },
+  "severity": "high" | "medium" | "low",
+  "suggestion": "Rebase payment-flow onto auth-flow before opening PR; ~12 overlapping lines.",
+}
+```
+
+### Severity heuristic
+
+- `high`: lines_both > 0 in any repo (genuine line-level overlap; rebase will conflict)
+- `medium`: same files modified, no line overlap (likely auto-mergeable but worth checking)
+- `low`: shared files but only in non-code areas (e.g., both touched `package.json` → likely a dep bump, often auto-mergeable)
+
+### CLI rendering
+
+```
+$ canopy conflicts
+
+  Conflicts (2 pairs)
+  ────────────────────────────────────────────────────
+  ⚠ auth-flow ↔ payment-flow                           high
+    test-api: 2 files, 12 lines overlapping
+    suggestion: rebase payment-flow onto auth-flow first
+
+  · doc-1001 ↔ doc-1003                                low
+    both touched package.json (likely a dep bump)
+```
+
+`--json` returns the structured per-pair list.
+
+---
+
+## State model changes
+
+None. Read-only — uses existing `feature_diff` per feature.
+
+---
+
+## Command surface changes
+
+| Today | After |
+|---|---|
+| `canopy conflicts` (does not exist) | New CLI command + MCP tool. |
+| `canopy triage` | Optional enrichment: when a feature has a high-severity conflict, surface a `conflicts_with: [feature]` field in the triage output. |
+| `canopy state <feature>` | Optional enrichment: per-repo conflict-with-other-features count surfaced in the state output. |
+
+The `triage` and `state` enrichments are optional follow-ons; the standalone `conflicts` command is the v1.
+
+---
+
+## Files to touch
+
+### New
+
+- `src/canopy/actions/conflicts.py` — orchestrator. Public function `find_conflicts(workspace, scope=None, include_cold=False) -> list[ConflictPair]`. Internally: enumerate features, compute per-feature changed-files via existing `feature_diff`, pairwise intersect, classify by severity, format suggestion.
+- `tests/test_conflicts.py` — fixture-driven cases:
+  - Two features touching disjoint files (no conflict reported)
+  - Two features sharing a file but disjoint lines (medium severity)
+  - Two features sharing lines (high severity)
+  - Three features with mixed overlap (returns 3 pairs)
+  - Single-repo features (no cross-repo aggregation)
+
+### Modified
+
+- `src/canopy/cli/main.py` — `cmd_conflicts(args)` + subparser.
+- `src/canopy/mcp/server.py` — register `conflicts(scope=None, with_=None, include_cold=False)` MCP tool.
+- `docs/commands.md` — add `conflicts` section.
+- `docs/agents.md` — add to the "before opening a PR" recipe.
+- (Follow-on) `actions/triage.py` + `actions/feature_state.py` — opt-in enrichments behind a config flag, deferred to a follow-up if v1 standalone tool is well-received.
+
+---
+
+## Tasks (rough sequence)
+
+### T1 — `feature_diff` reuse
+
+Verify `feature_diff` returns per-file change data we can intersect. The current return shape is `{summary, files: [...]}` with per-file insertions/deletions but maybe not per-line ranges. If only file-level data is exposed, line-level overlap requires a deeper read — `git diff --unified=0` parsing.
+
+Decision point: ship with file-level severity only (high = same file; we can't distinguish line-level without extra git calls), OR add `feature_diff_lines(feature) -> {repo: {file: [line_ranges]}}` as a new helper. The line-level helper is ~30 lines of git output parsing; worth doing for accurate severity.
+
+### T2 — Pairwise intersect
+
+Pure function `compute_overlap(diff_a, diff_b) -> dict[repo, OverlapEntry]`. Runs in O(features²) which is fine for typical N=10-20.
+
+Tests: synthetic diff fixtures.
+
+### T3 — Severity classifier + suggestion
+
+Pure function `classify(overlap) -> (severity, suggestion)`. Deterministic from the overlap shape.
+
+Tests: snapshot per representative input.
+
+### T4 — Orchestrator
+
+`find_conflicts(workspace, scope=None, include_cold=False)`. Composes: enumerate features → fetch diffs (parallelized) → pairwise intersect → classify → return.
+
+`scope` filters to one feature (returns pairs where that feature is one side). `include_cold` extends the feature set.
+
+### T5 — CLI + MCP
+
+Wrappers. CLI prints the grouped output; `--json` returns the structured list. MCP tool returns the same.
+
+### T6 — Docs + skills
+
+`docs/commands.md`, `docs/agents.md`. Skill files mention `conflicts` as part of the pre-PR checklist.
+
+---
+
+## Edge cases to remember
+
+- **Feature with no changes (just-created lane).** Skip — empty diff means no overlap with anyone.
+- **Feature touching only renamed files.** Renames count as "changed" by git. The overlap would surface — and it's actually informative (two features both renamed the same file is a real conflict).
+- **Generated files in the diff.** If both features touch `package-lock.json`, severity will be `high`, but the suggestion should note "package-lock.json is auto-generated; conflict is likely benign (re-run `pnpm install` after rebase)." Add a config-driven ignore list (`[workspace] conflict_ignore_files = ["package-lock.json", "*.lock", ...]`) for v1.1 — out of scope for v1.
+- **Performance with many features.** O(N²) on diff intersections. With N=50 features that's 1225 pairs — fine. Each diff is ~1KB; total memory ~50KB. Feasible.
+- **Stale `feature_diff` cache.** `feature_diff` reads from live git (worktree-aware). Conflicts always reflects current state of each feature's branch.
+
+---
+
+## Out of scope
+
+- **Three-way merge prediction.** "If A merges first, will B's rebase succeed?" Real merge simulation is hard (requires actually rebasing). v1 reports overlap; user judges.
+- **Conflict resolution suggestions.** The "suggestion" field is heuristic-based ("rebase A onto B first"); doesn't compute the actual rebase.
+- **Live monitoring.** No watcher daemon that surfaces conflicts as features grow. v1 is on-demand `canopy conflicts`.
+- **Cross-workspace conflicts.** One workspace per invocation.
+
+---
+
+## After this lands
+
+- Before opening a PR, the agent (or user) runs `canopy conflicts --feature <X>` and sees if any active feature's PR will need to rebase against this one. Proactive, not reactive.
+- The README's load-bearing table picks up another row: *"Two of your active features quietly touch the same file; conflict surfaces during PR rebase, not before."* → `canopy conflicts` is the proactive check.
+- Pairs with the (future) `ship` MCP tool (Wave 2.4 plan): `ship` could call `conflicts --feature <self>` first and warn before opening a PR that's about to step on another feature's toes.

--- a/docs/plans/doctor.md
+++ b/docs/plans/doctor.md
@@ -1,3 +1,10 @@
+---
+status: queued
+priority: P0
+effort: ~3-4d
+depends_on: []
+---
+
 # `canopy doctor` — state-file integrity checker + repair
 
 ## Why

--- a/docs/plans/doctor.md
+++ b/docs/plans/doctor.md
@@ -1,0 +1,246 @@
+# `canopy doctor` — state-file integrity checker + repair
+
+## Why
+
+Canopy keeps state in five places: `canopy.toml`, `.canopy/features.json`, `.canopy/state/heads.json`, `.canopy/state/active_feature.json`, `.canopy/state/preflight.json` — plus the per-repo `post-checkout` hooks and the `.canopy/worktrees/` directory tree. Every operation reads or writes some subset of these.
+
+Today, if any of these get out of sync — partial write after a crash, manual edit gone wrong, file-system snapshot restore, post-checkout hook silently uninstalled by another tool — canopy doesn't notice. The next operation reads stale state, makes a decision based on it, and either fails opaquely or compounds the corruption.
+
+`canopy doctor` is the safety net: walk every state file, cross-reference with live git + filesystem, surface inconsistencies with diagnostic codes, and auto-repair the obvious cases when invoked with `--fix`.
+
+This is the first thing a user (or agent) runs when they suspect "something is off" — before they go hunting through stash lists and worktree paths. Returns structured JSON so an agent can act on the findings programmatically.
+
+---
+
+## Behavioral spec
+
+`canopy doctor [--check | --fix | --fix=<category>] [--feature <X>]`
+
+Default mode is `--check`: report only, no modifications. `--fix` repairs every fixable issue. `--fix=<category>` repairs just one category (heads / worktrees / hooks / preflight / features). `--feature <X>` scopes the diagnosis to one feature instead of the whole workspace.
+
+### Diagnostic categories (each maps to a `code`)
+
+**`heads_stale`** — `.canopy/state/heads.json` has a per-repo head sha that doesn't match `git rev-parse HEAD` in that repo.
+- Cause: post-checkout hook didn't fire (e.g., hook uninstalled, race on concurrent checkout, file write failure)
+- Fix: rewrite `heads.json` from live git
+- Severity: warn (state will self-correct on next checkout)
+
+**`active_feature_orphan`** — `.canopy/state/active_feature.json` points at a feature that no longer exists in `features.json`.
+- Cause: manual `features.json` edit, `done` ran but didn't clear active state
+- Fix: clear `active_feature.json` (back to no-active-feature)
+- Severity: error (subsequent commands will misbehave)
+
+**`active_feature_path_missing`** — `active_feature.json` lists per-repo paths that don't exist on disk.
+- Cause: worktree manually deleted, filesystem restore
+- Fix: re-resolve paths from `features.json` + `lane.repo_states[*].worktree_path`
+- Severity: error
+
+**`worktree_orphan`** — directory in `.canopy/worktrees/` that isn't referenced by any feature in `features.json`.
+- Cause: feature done'd via raw git, partial cleanup, manual mkdir
+- Fix: prompt for removal (or `--fix` removes; `--fix-worktrees` honored, others ignored)
+- Severity: warn
+
+**`worktree_missing`** — `features.json` lists `worktree_path` for a feature × repo pair, but the directory doesn't exist.
+- Cause: filesystem restore, manual rm, partial done that updated features.json before removing dir (shouldn't happen but defense in depth)
+- Fix: clear the worktree_path entry; mark feature as cold for that repo
+- Severity: error
+
+**`hook_missing`** — repo doesn't have canopy's post-checkout hook installed (or has a different one not chaining canopy's).
+- Cause: hook uninstalled by another tool, fresh clone of an existing canopy workspace
+- Fix: re-run hook installation for that repo
+- Severity: error (drift detection will silently fail)
+
+**`hook_chained_unsafe`** — hook exists but the chain is broken (canopy's hook calls a previous hook that no longer exists, or a previous hook returns non-zero unexpectedly).
+- Cause: user reinstalled their global hooks, husky reset, etc.
+- Fix: surface the broken chain; recommend `canopy hooks reinstall` (existing command)
+- Severity: warn
+
+**`preflight_stale`** — `.canopy/state/preflight.json` records a passed result, but the recorded `head_sha_per_repo` no longer matches current HEAD on any of the repos.
+- Cause: commits made after preflight ran (preflight result is no longer authoritative for current state)
+- Fix: clear stale preflight entries
+- Severity: info (not strictly broken, just no longer valid signal)
+
+**`features_unknown_repo`** — `features.json` references a repo name that's not in `canopy.toml`.
+- Cause: repo removed from canopy.toml without `done`-ing affected features
+- Fix: surface; no auto-fix (user has to decide whether to remove the feature or restore the repo)
+- Severity: error
+
+**`branches_missing`** — feature has `branches[repo]` set to a branch name that doesn't exist as a local branch in the repo.
+- Cause: user deleted the branch via raw git, accidental `done` partial run
+- Fix: surface; offer to remove the feature (no auto-fix)
+- Severity: error
+
+### Output shape (--json)
+
+```python
+{
+  "workspace": "canopy-test",
+  "checked_at": "2026-04-28T12:34:56Z",
+  "issues": [
+    {
+      "code": "heads_stale",
+      "severity": "warn",
+      "what": "heads.json out of sync for test-api",
+      "expected": "abc123de",
+      "actual": "9c2e1abc",
+      "repo": "test-api",
+      "fix_action": "rewrite heads.json from live git",
+      "auto_fixable": true,
+    },
+    ...
+  ],
+  "summary": {"errors": 1, "warnings": 2, "info": 0},
+  "fixed": [],     # populated when --fix ran
+  "skipped": [],   # issues that --fix couldn't repair
+}
+```
+
+### CLI rendering
+
+Issues grouped by severity, with `severity glyph` (✗ error / ! warn / · info), code, and one-line `what`. `--verbose` adds `expected` / `actual`. `--fix` shows what was repaired.
+
+---
+
+## State model changes
+
+None. Doctor reads existing state, repairs in place. Doesn't introduce new state files.
+
+---
+
+## Command surface changes
+
+| Today | After |
+|---|---|
+| `canopy doctor` (does not exist) | New CLI command + MCP tool. |
+| `canopy hooks reinstall` (existing — see `cmd_hooks`) | Unchanged. Doctor surfaces a `hook_missing` issue with a recommendation pointing at it. |
+| `canopy workspace reinit` (existing) | Unchanged. Doctor recommends it for `features_unknown_repo` and similar wide-scope issues. |
+
+---
+
+## Files to touch
+
+### New
+
+- `src/canopy/actions/doctor.py` — orchestrator. One check function per category (each pure: takes workspace, returns list of `Issue` dataclass). Aggregator runs all checks (or a subset), composes the structured result. Repair functions are separate (each takes the issue, returns repair-result).
+- `tests/test_doctor.py` — table-driven cases for each category. Use `workspace_with_feature` fixture + targeted state-file mutations.
+
+### Modified
+
+- `src/canopy/cli/main.py` — `cmd_doctor(args)`, dispatch + subparser. Render via existing `cli/render.py` style.
+- `src/canopy/mcp/server.py` — register `doctor(check=True, fix=False, fix_categories=None, feature=None)` MCP tool.
+- `docs/commands.md` — `doctor` section with example output.
+- `docs/agents.md` — agent recipe: "if a canopy operation returns an unexpected error, call `mcp__canopy__doctor` first to see whether state is corrupted."
+- Both skill files — flag `doctor` as the recovery entry point.
+
+---
+
+## Tasks (rough sequence)
+
+### T1 — `Issue` dataclass + check protocol
+
+`actions/doctor.py:Issue(code, severity, what, expected, actual, repo, feature, fix_action, auto_fixable)`. Each check function returns `list[Issue]`. Pure — takes workspace, no side effects.
+
+### T2 — One check per category
+
+Implement nine check functions (one per code in the matrix above). Each is a small pure function reading specific state files / git output and producing zero or more `Issue` records.
+
+Tests: per-category fixtures that create a known-bad state, assert the right issues are reported.
+
+### T3 — Repair functions
+
+Per category, a `repair_<category>(workspace, issue) -> RepairResult` function. RepairResult has `{success, action_taken, error?}`. Repairs either: rewrite a state file, remove a worktree, reinstall a hook, or surface "no auto-fix possible."
+
+Tests: per-category fixture, run check → repair → re-check → assert clean.
+
+### T4 — Aggregator orchestrator
+
+`doctor(workspace, fix=False, fix_categories=None, feature=None)`. Runs all checks (or filtered to feature scope), collects issues, optionally runs repairs, returns the structured result dict.
+
+### T5 — CLI rendering
+
+Group by severity, show counts, render each issue. `--verbose` for expected/actual. `--fix` shows repaired issues.
+
+### T6 — MCP tool registration
+
+Thin wrapper over the action. Returns the structured dict directly.
+
+### T7 — Docs + skills
+
+`docs/commands.md`, `docs/agents.md`, both skill files updated.
+
+### T8 — Recovery integration test
+
+End-to-end: workspace with feature → corrupt heads.json → call `doctor` → assert issues reported → call with `--fix` → assert state repaired → assert `doctor` returns clean.
+
+---
+
+## Edge cases to remember
+
+- **Concurrent ops while doctor runs.** If a switch is happening in another terminal, doctor might see transient state. Doctor reads with a short retry/stabilize loop (read state, wait 100ms, re-read; if changed, defer the issue). Not a hard guarantee.
+- **Doctor itself corrupts state on `--fix`.** Every repair writes to a tmp file then atomic-renames. If the rename fails, the original is preserved.
+- **Hook detection on Husky workspaces.** Husky sets `core.hooksPath`. Doctor respects that — looks for canopy's hook in the configured hooksPath, not just `.git/hooks/`.
+- **Workspace with no features.** Most checks short-circuit cleanly (empty issue list). Don't surface "no features" as an issue.
+- **`--fix` and worktree removal.** Removing an orphan worktree dir uses `git worktree remove --force` to ensure git's worktree registry is cleaned. Doctor prompts confirmation in CLI mode (skipped with `--yes`); MCP mode auto-confirms (the agent invoked it, presumably knowing what it's doing).
+
+---
+
+## Out of scope
+
+- **Predictive diagnostics.** Doctor reports current-state issues, not "your workflow is going to break in 3 commits." Static analysis of features.json beyond cross-references is out.
+- **Cross-workspace doctor.** One workspace per invocation.
+- **Linear / GitHub external state.** Doctor doesn't reach out to verify Linear issue exists or PR is open. That's `triage` / `review_status` territory. Boundaries respected.
+
+---
+
+## After this lands
+
+- An agent that gets an unexpected error from any canopy MCP call has a clear next-step: call `doctor`. Recovery becomes mechanical.
+- Users with shared workspaces (multiple shells, occasional crashes) have a one-command sanity check.
+- The README's "Why it's load-bearing" table picks up another row: *"Canopy state files get out of sync — heads.json is stale after a crash, an orphan worktree directory lingers from a partial done."* → `canopy doctor` finds and fixes.
+- Pairs with the `audit log` plan (if shipped) — doctor can read the recent audit trail to suggest causes for issues found.
+
+---
+
+## Addendum (2026-05-02) — Install-staleness categories + version handshake
+
+The original "canopy upgrade" plan was absorbed into doctor: machine-level artifact staleness (CLI / MCP / vsix / skill / .mcp.json) is the same kind of work as workspace-state-file integrity (diagnose → classify → repair). One unified `canopy doctor` command, growing taxonomy.
+
+### Six new diagnostic categories (added on top of the original 9)
+
+| Code | Severity | Detection | Repair |
+|---|---|---|---|
+| `cli_stale` | warn | `canopy --version` < `__version__` (sourced from `src/canopy/__init__.py`) | re-pip-install or re-pipx-install (detected from install method) |
+| `mcp_stale` | error | MCP `version()` tool returns version < `__version__`, or tool missing entirely | reinstall the canopy-mcp venv via the existing `runInstallBackend` pattern from the extension |
+| `mcp_missing_in_workspace` | error | `<workspace>/.mcp.json` lacks a `canopy` entry, or its `CANOPY_ROOT` doesn't match the workspace root | `install_mcp(workspace_root, reinstall=True)` |
+| `skill_missing` | warn | no `SKILL.md` at `~/.claude/skills/<name>/` for any skill in the configured list (`using-canopy`, `augment-canopy`, future) | `install_skill(name)` for each missing |
+| `skill_stale` | warn | byte-compare against the bundled source returns mismatch | `install_skill(name, reinstall=True)` |
+| `vsix_duplicates` | info | multiple `singularityinc.canopy-*` directories in `~/.vscode/extensions/` | report stale candidates; `--clean-vsix` flag removes non-current versions (active version preserved) |
+
+Total diagnostic categories after this addendum: **15** (9 original + 6 install-staleness).
+
+### Version handshake (precondition for the new categories)
+
+Three reporting layers, all sourcing from `src/canopy/__init__.py:__version__`:
+
+- **CLI:** `canopy --version` (argparse `version` action)
+- **MCP server:** new `version()` MCP tool returning `{cli_version, mcp_version, schema_version}`. Schema version starts at `"1"` and bumps on canopy.toml schema changes (independent of the package version).
+- **VSCode extension:** at MCP startup, calls `version()` once. Logs a warning on minor version mismatch; refuses activation on major mismatch with a toast offering `canopy doctor --fix`.
+
+### Files to touch (additions)
+
+- `src/canopy/__init__.py` — `__version__` constant (sourced from `pyproject.toml`)
+- `src/canopy/cli/main.py` — `--version` argparse action; `cmd_doctor` extended to call install-staleness checks
+- `src/canopy/mcp/server.py` — register the new `version()` tool
+- `src/canopy/actions/doctor.py` — six new check functions + six new repair functions, slotted into the existing `Issue` / repair pattern
+- `vscode-extension/src/canopyClient.ts` — version handshake on MCP startup
+- `tests/test_doctor.py` — extend with install-staleness fixtures (mock binaries with stale version output, missing skill/mcp.json, vsix dir scenarios)
+
+### New CLI flags
+
+- `canopy doctor --check` (existing, no behavior change) — adds the 6 new categories to the report
+- `canopy doctor --fix` (existing) — repairs everything fixable; `cli_stale` and `mcp_stale` repairs may require a process restart, returning `BlockerError(code='reload_required', fix_action='reload window')` rather than blocking silently
+- `canopy doctor --clean-vsix` (new) — extends `--fix` to also remove `vsix_duplicates`-flagged stale extension dirs
+
+### Sequence note
+
+This addendum's categories require the `__version__` constant + the `version()` MCP tool to exist. They land together in the doctor PR, not as a separate version-handshake PR. The vsix duplicate detector and the skill-staleness checker have no version dependency and could ship slightly earlier in development if useful.

--- a/docs/plans/historian.md
+++ b/docs/plans/historian.md
@@ -1,3 +1,10 @@
+---
+status: queued
+priority: P1
+effort: ~5-6d
+depends_on: ["bot-tracking.md"]
+---
+
 # Historian — cross-session feature memory
 
 ## Why

--- a/docs/plans/historian.md
+++ b/docs/plans/historian.md
@@ -1,0 +1,179 @@
+# Historian — cross-session feature memory
+
+## Why
+
+Agents waste 30–50% of their context on bookkeeping every session: re-parsing PR state, re-deriving "is this comment still actionable?", re-discovering past decisions. When an agent picks up a feature it (or another agent) was working on Monday, by Wednesday it has zero context — the user has to re-explain "we were halfway through wiring up empty-state, blocked on design-system copy."
+
+Historian moves that knowledge into a persistent markdown memory file per feature, written automatically as the agent works, read automatically on `canopy switch`. The handoff scenario:
+
+- Monday: 2 hours on `sin-7-empty-state`. Agent reads design docs, edits 3 files, runs preflight, blocked on copy from design system, pauses.
+- Tuesday: switch to `sin-6-cache-stats`, work there.
+- Wednesday: `canopy switch sin-7-empty-state` — agent's response includes the memory file; agent knows immediately what was decided, what's resolved, where it left off. No re-derivation.
+
+This eliminates an entire class of context-loss tax that's invisible to users because they've adapted to it.
+
+## Goal
+
+A persistent markdown file per feature (`<workspace>/.canopy/memory/<feature>.md`) that:
+
+- Captures decisions, events, comment activity, and PR context across sessions
+- Is auto-read on `canopy switch` (response includes a `memory: <markdown>` field)
+- Is auto-written via PostToolUse hooks (events, comment activity, PR context) and explicit MCP calls (decisions, pauses)
+- Renders in three sections: Resolutions log (structured, never compacted), PR context, Sessions (newest first, older sessions LLM-compacted)
+
+## Non-goals
+
+- LLM-based summarization on every event (too slow, too costly). Compaction is the only LLM call, and only on switch-away.
+- Cross-machine memory sync. Memory is local to the workspace's `.canopy/memory/` and follows the workspace.
+- Replacing PR descriptions or commit messages. Historian is for *in-session work* — commits and PRs remain separate.
+- Conflict-free distributed memory (CRDT). Just append-only with file locks; rare conflicts get resolved by manual edit.
+- Per-machine memory (memory is per-workspace, not per-machine).
+
+## Eight capture categories
+
+| # | Category | Examples | Trigger |
+|---|---|---|---|
+| 1 | Decisions | "chose `jwt.decode` over `pyjwt`; reason: stdlib only" | **Hybrid** (see Capture mechanism below): primary `mcp__canopy__historian_decide` + Stop-hook tail-parse backup |
+| 2 | Events | "edited `src/auth/oauth.py`", "ran preflight (passed)" | PostToolUse hook on Bash + Edit (in active worktree only); summarized to one line |
+| 3 | Pauses | "blocked on design-system copy; need confirmation from Phil" | Stop hook (end of agent session) or explicit `historian_pause` |
+| 4 | Comments read | "read coderabbit comment on `src/api/cache.py:42` — suggested rename `hit_rate → cache_hit_rate`" | PostToolUse on `review_comments` MCP call; logs each unique comment URL once per session |
+| 5 | Comments resolved | "addressed comment 123456 in `abc123de`: renamed `hit_rate → cache_hit_rate` per suggestion" | PostToolUse on `commit --address` (consumes N2's bot-resolutions flow); pulls comment title + commit sha + diff snippet |
+| 6 | Classifier-resolved | "temporal classifier marked these 3 threads likely-resolved (file already touched in commits since)" | PostToolUse on `review_comments` when classifier output includes `likely_resolved` entries; logged once per session |
+| 7 | PR context | "opened PR #142 against main. Includes commits abc/def/ghi. Rationale: implements SIN-7 cache stats; closes 3 actionable threads from review round 1" | PostToolUse on `ship` MCP tool (Wave 2.4) or explicit `historian_pr_opened` |
+| 8 | PR updates | "pushed 2 commits to PR #142: addressed bot comment 789, added test for the cache-hit-rate edge case" | PostToolUse on `push` MCP tool (when an open PR exists for the feature) |
+
+Categories 4–8 are the agent-handoff layer — the new agent reads the memory and can answer "is comment X resolved?", "what's the rationale for this PR?", and "what was the last action?" without scrolling through `gh pr view` or re-deriving state.
+
+## Capture mechanism for decisions (hybrid)
+
+Explicit MCP tool calls (primary) + Stop-hook tail-parse (backup).
+
+- **Primary: explicit tool calls.** Skill teaches the agent to call `mcp__canopy__historian_decide(feature, decisions=[...])` after committing to an approach (after a commit, after a pivot, on pause). Reliable; structured input validated by the MCP protocol.
+- **Backup: Stop-hook tail-parse.** Skill teaches: at end of turn where you decided something but didn't call the tool, emit `<historian-decisions>[{title, rationale}, ...]</historian-decisions>` in the response. Stop hook scans the last assistant message; parses; writes any decisions not already captured (deduped by title).
+- **Rejected: extra-prompt round-trip.** A hook that fires after commit and asks the agent "any decisions worth recording?" wastes an LLM turn given the tool-call primitive exists.
+
+The hybrid handles two failure modes: (a) agent forgets to call the tool but mentions the decision in their response (tail-parse rescue), (b) agent does both (deduped by title). Format-only would have ~5–10% silent gaps in long sessions; tool-only would miss free-text decisions that didn't trigger an explicit call. The hybrid pushes silent-gap rate to near zero.
+
+## File format (`.canopy/memory/<feature>.md`)
+
+Three top-level sections, newest content first within each:
+
+```markdown
+# Feature: <name> · <linear-id>
+
+## Resolutions log
+- ✓ comment <id> (<author>, <file:line>) resolved by <sha>
+  <gist of resolution>
+- ⊙ comment <id> (<author>, <file:line>) likely-resolved by classifier
+  <classifier rationale>
+- ⚠ comment <id> (<author>, <file:line>) UNRESOLVED
+  <last status>
+- ⊘ comment <id> (<author>, <file:line>) DEFERRED
+  <deferral reason>
+
+## PR context
+### PR #<n> — <title>
+**Opened:** <date> against <base>
+**Branch:** <feature>
+**Rationale:** <why this PR>
+**Commits:** <count>; review rounds: <n>
+
+### Updates
+- <date>: <action>
+  ...
+
+## Sessions (newest first)
+### <date> — <status>
+**Where we are:** ...
+**Last decision:** ...
+**Open questions:** ...
+**Last command:** ...
+**Touched:** ...
+```
+
+The Resolutions log + PR context sections are **never compacted** — they're the always-current source of truth. Sessions get LLM-compacted on switch-away.
+
+## Switch integration
+
+`mcp__canopy__switch(feature)` response includes a `memory: <markdown>` field for the new active feature. Agent sees memory immediately on switch — no extra MCP call.
+
+```python
+# After switch_impl():
+result["memory"] = format_for_agent(workspace, feature)  # renders the .md
+```
+
+## Compaction
+
+Old sessions get LLM-summarized when:
+- (a) `canopy switch <other>` — compact the just-finished session of the previously-active feature
+- (b) Explicit `mcp__canopy__historian_compact(feature)`
+
+Resolution log + PR context sections are NEVER compacted. Only the Sessions section.
+
+The compaction LLM call is the only LLM call in the historian flow. Everything else is mechanical.
+
+## New CLI / MCP surface
+
+- `mcp__canopy__historian_decide(feature, decisions: list[{title, rationale}])` — log decisions
+- `mcp__canopy__historian_pause(feature, reason: str)` — log pause
+- `mcp__canopy__historian_defer_comment(feature, comment_id: str, reason: str)` — log deferral with rationale
+- `mcp__canopy__feature_memory(feature)` — read full memory as markdown
+- `mcp__canopy__historian_compact(feature)` — manual compaction trigger
+- `canopy historian show <feature>` — CLI inspection (read-only)
+- `canopy historian compact <feature>` — CLI manual compact
+
+## Files to touch
+
+- **New:** `src/canopy/actions/historian.py` — `record_decision`, `record_event`, `record_pause`, `record_comment_read`, `record_comment_resolved`, `record_comment_deferred`, `record_pr_context`, `record_pr_update`, `compact`, `read`, `format_for_agent`
+- **New:** `tests/test_historian.py`
+- `src/canopy/mcp/server.py` — register the 5 historian tools (`historian_decide`, `historian_pause`, `historian_defer_comment`, `feature_memory`, `historian_compact`)
+- `src/canopy/cli/main.py` — `cmd_historian_show`, `cmd_historian_compact` (read-only inspection + manual compact trigger)
+- `src/canopy/actions/switch.py` — extend response with `memory: <markdown>` field via `format_for_agent(feature)` call
+- `src/canopy/actions/commit.py` — when `--address` succeeds, also call `record_comment_resolved` (extends N2's flow)
+- `src/canopy/actions/reads.py` — when `review_comments` returns, call `record_comment_read` and `record_classifier_resolved`
+- `src/canopy/agent_setup/skills/using-canopy/SKILL.md` — teach: read memory on switch; call `historian_decide` at meaningful moments; emit `<historian-decisions>` tail as fallback
+- Stop hook (autopilot integration): scan last assistant message for `<historian-decisions>` block; parse; dedup against tool-call writes; persist
+- PostToolUse hooks (autopilot integration): events for Bash/Edit, comment-read for `review_comments`, comment-resolved for `commit --address`, pr-context for `ship`, pr-update for `push`
+
+## Implementation order
+
+1. New `actions/historian.py`. File IO + record functions for each category. Pure module; unit-tested independently.
+2. MCP tool registration. The 5 new tools wrap the record functions.
+3. Skill update: `using-canopy/SKILL.md` gains a "Historian" section teaching when to call each tool, plus the tail-fallback format.
+4. Switch integration: extend `switch_impl` response with `memory: format_for_agent(feature)`.
+5. Hooks integration: PostToolUse + Stop hook bundle (lands as part of autopilot's observer category).
+6. Commit + review integration: extend N2's `commit --address` flow to call `record_comment_resolved`; extend `review_comments` reads to call `record_comment_read` and `record_classifier_resolved`.
+7. Compaction: LLM-summarize old sessions; trigger on switch-away.
+
+## Verification
+
+- Unit: each `record_*` appends correctly; `format_for_agent` renders all 3 sections in order; compaction summarizes without losing resolution log or PR context.
+- Integration: `workspace_with_feature` → simulate session: `review_comments` call → `commit --address` → `historian_decide` → switch away → switch back → assert memory has resolution-log entry + classifier-resolved entry + decision entry + session entry.
+- Hybrid mechanism: agent calls `historian_decide` directly: persisted once. Agent emits format-tail without tool call: Stop-hook persists. Agent does both with same title: deduped to one entry.
+- Manual: real PR with bot comments → use canopy normally for an hour → `canopy historian show <feature>` → eyeball that memory captures decisions, events, resolutions, classifier output, PR context.
+
+## Edge cases
+
+- **Privacy / secrets in tool output.** Bash output can contain API keys, paths, tokens. Hook-based event capture redacts aggressively: defaults to NOT logging tool output (just tool name + 1-line summary). User opts into verbose logging per category.
+- **Multi-agent contention on same feature.** Two agents writing to `.canopy/memory/<feature>.md` simultaneously — solved with append-only writes + `fcntl.flock` (same pattern as `heads.json`). Each event is its own line; agents don't overwrite each other.
+- **Stale context after long absence.** If the codebase has changed since the last session, old memory might mislead. Mitigation: compaction includes a "since last session" diff summary so the agent knows what's changed independently of what was logged.
+- **Cross-feature crosstalk.** Memory must be strictly scoped to the feature. If the agent is in `sin-7` and asks about `sin-6`, they shouldn't accidentally get sin-6's memory. Strict per-feature scoping.
+- **PostToolUse hook noise.** PostToolUse on every Bash + Edit is noisy. Filter: only fire on `Bash(git ...)` and `Edit(...)` of files in the *active* feature's worktree. Anything else passes through unlogged.
+- **Comment marked likely_resolved → re-opened.** A comment marked "likely_resolved" in session 1 might be re-opened in session 3 (reviewer adds a follow-up). Historian re-renders the temporal classifier's current output; doesn't manually clean up. The classifier handles the transition.
+
+## Effort
+
+~5–6 days. Depends on autopilot's Stop + PostToolUse hook infrastructure being in place; if those slip, historian's auto-capture (categories 2, 4, 5, 6, 7, 8) defers and only categories 1 (decisions, hybrid) and 3 (pauses, explicit) ship in v1.
+
+## Dependencies
+
+- **N2 (bot-tracking):** historian's "comments resolved" log consumes N2's `bot_resolutions.json` + `commit --address` flow as data sources. Without N2, historian would have to reimplement structured comment-resolution state.
+- **Augments (N3):** the `review_bots` augment list scopes which authors count as bots for the comments-read / comments-resolved categories. Without it, historian falls back to the hardcoded `author_type == "Bot"` substring.
+- **Autopilot observer hooks:** historian's auto-capture for events / comment-activity / PR-context relies on the PostToolUse + Stop hook bundle.
+
+## After this lands
+
+- An agent picking up `sin-7` after a 3-day gap reads the memory on switch and knows immediately: what was decided, which comments are resolved, which are deferred, what's still open. No re-derivation.
+- The README's "Why it's load-bearing" table picks up another row: *"Cross-session context loss: agent re-derives PR state, past decisions, file context every session."* → historian is the persistent memory layer that makes session boundaries seamless.
+- Pairs with future agent-driven workflows (multi-step refactors, long-running PR review loops): historian carries the narrative; structured state files (`bot_resolutions.json`, `heads.json`, etc.) carry the lookup.
+- Auto-population of agent context becomes a pattern other plans can adopt: when a new feature requires persistent narrative, follow historian's shape.

--- a/docs/plans/historian.md
+++ b/docs/plans/historian.md
@@ -42,7 +42,7 @@ A persistent markdown file per feature (`<workspace>/.canopy/memory/<feature>.md
 |---|---|---|---|
 | 1 | Decisions | "chose `jwt.decode` over `pyjwt`; reason: stdlib only" | **Hybrid** (see Capture mechanism below): primary `mcp__canopy__historian_decide` + Stop-hook tail-parse backup |
 | 2 | Events | "edited `src/auth/oauth.py`", "ran preflight (passed)" | PostToolUse hook on Bash + Edit (in active worktree only); summarized to one line |
-| 3 | Pauses | "blocked on design-system copy; need confirmation from Phil" | Stop hook (end of agent session) or explicit `historian_pause` |
+| 3 | Pauses | "blocked on design-system copy; need product confirmation" | Stop hook (end of agent session) or explicit `historian_pause` |
 | 4 | Comments read | "read coderabbit comment on `src/api/cache.py:42` — suggested rename `hit_rate → cache_hit_rate`" | PostToolUse on `review_comments` MCP call; logs each unique comment URL once per session |
 | 5 | Comments resolved | "addressed comment 123456 in `abc123de`: renamed `hit_rate → cache_hit_rate` per suggestion" | PostToolUse on `commit --address` (consumes N2's bot-resolutions flow); pulls comment title + commit sha + diff snippet |
 | 6 | Classifier-resolved | "temporal classifier marked these 3 threads likely-resolved (file already touched in commits since)" | PostToolUse on `review_comments` when classifier output includes `likely_resolved` entries; logged once per session |

--- a/docs/plans/providers-arch.md
+++ b/docs/plans/providers-arch.md
@@ -9,7 +9,7 @@ depends_on: []
 
 ## Why
 
-Canopy's read tools today are tightly coupled to specific external services — `linear_get_issue`, `linear_my_issues`, `github_get_pr`, etc. That works while you're using exactly those services, but the moment a new user (e.g., Phil in [issue #5](https://github.com/ashmitb95/canopy/issues/5)) wants GitHub Issues instead of Linear, every action that touches issue context has to branch on which integration to call. That branching is exactly the kind of code that ages badly and bleeds Linear-shaped assumptions into the contract.
+Canopy's read tools today are tightly coupled to specific external services — `linear_get_issue`, `linear_my_issues`, `github_get_pr`, etc. That works while we're using exactly those services, but the moment we (or anyone) wants GitHub Issues instead of Linear, every action that touches issue context has to branch on which integration to call. That branching is exactly the kind of code that ages badly and bleeds Linear-shaped assumptions into the contract.
 
 This document defines the provider-injection pattern, scoped to **issue providers** specifically. The pattern is general enough that other concerns (CI providers, code-review platforms, IDE workspace formats, pre-commit frameworks, bot-author detection) could adopt it later, but those use cases are explicitly *named, not specified* in v1 — they only adopt the pattern if it drops in seamlessly during implementation.
 
@@ -20,7 +20,7 @@ A provider-agnostic interface for issue providers, defined as a Python protocol,
 - A discovery mechanism for finding installed providers
 - A configuration mechanism in `canopy.toml` for picking which provider a workspace uses
 - A dependency-injection point in the action layer so providers are swappable without touching call sites
-- Two reference implementations: Linear (refactored from `integrations/linear.py`) and GitHub Issues (new for Phil)
+- Two reference implementations: Linear (refactored from `integrations/linear.py`) and GitHub Issues (new)
 
 ## Doc structure
 
@@ -29,7 +29,7 @@ This is the v1 architecture doc. Code lands in subsequent plans (`docs/plans/iss
 ### 1. Motivation
 
 Why provider injection:
-- **Phil's ask** in issue #5: GitHub Issues as a first-class alternative to Linear.
+- **External signal** ([issue #5](https://github.com/ashmitb95/canopy/issues/5)): GitHub Issues as a first-class alternative to Linear.
 - **Future-proofing**: every team has different issue trackers. Hardcoding Linear (or any single one) limits canopy's reach.
 - **Multi-provider workspaces**: rare but real — a monorepo with one repo on Linear and another on JIRA. v1 is workspace-level only; per-repo override is reserved for a future plan.
 
@@ -89,7 +89,7 @@ How canopy finds providers:
 
 **v1: bundled.** Canopy ships built-in modules:
 - `canopy.providers.linear` (refactored from `integrations/linear.py`)
-- `canopy.providers.github_issues` (new for Phil)
+- `canopy.providers.github_issues` (new)
 
 A small registry in `canopy.providers.__init__.py`:
 

--- a/docs/plans/providers-arch.md
+++ b/docs/plans/providers-arch.md
@@ -1,0 +1,253 @@
+# Architecture: provider-injection contract (issue providers)
+
+## Why
+
+Canopy's read tools today are tightly coupled to specific external services — `linear_get_issue`, `linear_my_issues`, `github_get_pr`, etc. That works while you're using exactly those services, but the moment a new user (e.g., Phil in [issue #5](https://github.com/ashmitb95/canopy/issues/5)) wants GitHub Issues instead of Linear, every action that touches issue context has to branch on which integration to call. That branching is exactly the kind of code that ages badly and bleeds Linear-shaped assumptions into the contract.
+
+This document defines the provider-injection pattern, scoped to **issue providers** specifically. The pattern is general enough that other concerns (CI providers, code-review platforms, IDE workspace formats, pre-commit frameworks, bot-author detection) could adopt it later, but those use cases are explicitly *named, not specified* in v1 — they only adopt the pattern if it drops in seamlessly during implementation.
+
+## Goal
+
+A provider-agnostic interface for issue providers, defined as a Python protocol, with:
+- A small contract that any backend can implement
+- A discovery mechanism for finding installed providers
+- A configuration mechanism in `canopy.toml` for picking which provider a workspace uses
+- A dependency-injection point in the action layer so providers are swappable without touching call sites
+- Two reference implementations: Linear (refactored from `integrations/linear.py`) and GitHub Issues (new for Phil)
+
+## Doc structure
+
+This is the v1 architecture doc. Code lands in subsequent plans (`docs/plans/issue-providers.md` for the first scaffold).
+
+### 1. Motivation
+
+Why provider injection:
+- **Phil's ask** in issue #5: GitHub Issues as a first-class alternative to Linear.
+- **Future-proofing**: every team has different issue trackers. Hardcoding Linear (or any single one) limits canopy's reach.
+- **Multi-provider workspaces**: rare but real — a monorepo with one repo on Linear and another on JIRA. v1 is workspace-level only; per-repo override is reserved for a future plan.
+
+### 2. The contract
+
+Python protocol / abstract base for an issue provider:
+
+```python
+from typing import Protocol
+from dataclasses import dataclass
+
+@dataclass
+class Issue:
+    """Canonical issue shape canopy operates on, regardless of source provider."""
+    id: str                  # provider-internal id (Linear UUID, GH issue number, etc.)
+    identifier: str          # human-readable key (SIN-7, #142, JIRA-PROJ-123)
+    title: str
+    description: str | None
+    state: str               # canonical states: "todo" | "in_progress" | "done" | "cancelled"
+    url: str
+    assignee: str | None
+    labels: list[str]
+    priority: int | None     # 1=urgent, 2=high, 3=medium, 4=low; provider-mapped
+
+class IssueProvider(Protocol):
+    """Contract every issue provider must implement."""
+
+    def get_issue(self, alias: str) -> Issue:
+        """Resolve an alias to an issue. Alias formats vary by provider:
+        - Linear: 'SIN-7'
+        - GitHub Issues: '#142' or 'owner/repo#142'
+        Raises BlockerError(code='issue_not_found', ...) when not resolvable.
+        """
+
+    def list_my_issues(self, limit: int = 50) -> list[Issue]:
+        """Return the current user's open issues, ordered by recency or priority."""
+
+    def format_branch_name(
+        self,
+        issue_id: str,
+        title: str | None = None,
+        custom_name: str | None = None,
+    ) -> str:
+        """Provider-specific slug rules. Linear uses 'sin-7-add-search'; GitHub Issues
+        might use 'gh-142-add-search'. Custom name overrides the default slug."""
+
+    # Optional: lifecycle automation. v1 contract reserves the slot; first
+    # implementations may raise NotImplementedError. Future plans wire this.
+    def update_issue_state(self, alias: str, new_state: str) -> None: ...
+```
+
+The `Issue` dataclass is the canonical type the action layer consumes. Per-provider mapping (Linear's state names → canopy's, GitHub Issues' labels → canopy's priority field) lives inside each backend.
+
+### 3. Discovery
+
+How canopy finds providers:
+
+**v1: bundled.** Canopy ships built-in modules:
+- `canopy.providers.linear` (refactored from `integrations/linear.py`)
+- `canopy.providers.github_issues` (new for Phil)
+
+A small registry in `canopy.providers.__init__.py`:
+
+```python
+_REGISTRY: dict[str, type[IssueProvider]] = {
+    "linear": LinearProvider,
+    "github_issues": GitHubIssuesProvider,
+}
+
+def get_issue_provider(workspace: WorkspaceConfig) -> IssueProvider:
+    """Return the configured provider for the workspace, instantiated and cached."""
+    name = workspace.issue_provider.name  # from canopy.toml
+    cls = _REGISTRY.get(name)
+    if cls is None:
+        raise BlockerError(code='unknown_issue_provider', what=f"'{name}' is not a known provider", fix_actions=[...])
+    return cls(workspace.issue_provider.config)
+```
+
+**Future: entry points.** Third-party providers register via `pyproject.toml` entry points (`canopy.providers` group). Out of scope for v1.
+
+### 4. Configuration
+
+How the user/workspace picks a provider — top-level `[issue_provider]` block in `canopy.toml`:
+
+```toml
+[issue_provider]
+name = "linear"
+api_key_env = "LINEAR_API_KEY"   # or in a [issue_provider.linear] sub-table
+```
+
+GitHub Issues:
+
+```toml
+[issue_provider]
+name = "github_issues"
+repo = "owner/repo"              # which GH repo hosts the issues for this workspace
+```
+
+Provider-specific config goes in a `[issue_provider.<name>]` sub-table when there are multiple keys:
+
+```toml
+[issue_provider]
+name = "github_issues"
+
+[issue_provider.github_issues]
+repo = "owner/repo"
+labels_filter = ["good first issue", "help wanted"]   # optional
+```
+
+**Per-repo override** is reserved for a future plan. v1 is workspace-level only.
+
+### 5. DI wiring
+
+How the action layer obtains the provider instance:
+
+- New module `src/canopy/providers/__init__.py` exposes `get_issue_provider(workspace) -> IssueProvider`.
+- Cached per-workspace; constructed lazily on first access.
+- Action code calls `get_issue_provider(ws).get_issue(alias)` instead of `linear.get_issue(workspace.config.root, alias)`.
+
+Call sites to update (search for current direct `linear.*` calls):
+
+- `src/canopy/actions/reads.py:linear_get_issue`
+- `src/canopy/actions/reads.py:linear_my_issues`
+- `src/canopy/features/coordinator.py:worktree_create` (Linear lookup for issue title)
+- `src/canopy/cli/main.py:cmd_issue` (CLI command)
+- `src/canopy/mcp/server.py` (the `linear_*` MCP tools)
+
+The `linear_*` MCP tools become deprecation aliases:
+
+```python
+@mcp.tool()
+def linear_get_issue(alias: str) -> dict:
+    """Deprecated: use issue_get."""
+    # implementation: just calls issue_get
+```
+
+New canonical tools: `issue_get`, `issue_list_my_issues`. The old names continue to work for one release cycle.
+
+### 6. Backward compatibility
+
+Existing code paths:
+
+- Current `integrations/linear.py` becomes the Linear backend implementing the contract. Its public API is preserved during the transition; nothing in the action layer changes shape, just *who* it calls.
+- Current `integrations/github.py` PR/branch logic stays separate. PR-platform integration is a different concern from issue-tracker integration; the gh fallback for PRs is fine as-is.
+- Existing `mcp__canopy__linear_get_issue` MCP tool keeps working (deprecated alias for `mcp__canopy__issue_get` once the new tool ships).
+- Existing `canopy.toml` files without `[issue_provider]` block default to `linear` for backward compatibility (warn with a deprecation notice; v0.X removes the default).
+
+### 7. Examples
+
+#### Linear backend (refactored)
+
+Most logic moves verbatim from `integrations/linear.py`; the wrapping changes:
+
+```python
+class LinearProvider:
+    def __init__(self, config: dict):
+        self.api_key_env = config.get("api_key_env", "LINEAR_API_KEY")
+
+    def get_issue(self, alias: str) -> Issue:
+        # existing Linear MCP fallback logic
+        raw = _fetch_linear_issue(alias, env_key=self.api_key_env)
+        return Issue(
+            id=raw["id"],
+            identifier=raw["identifier"],
+            title=raw["title"],
+            description=raw.get("description"),
+            state=_map_linear_state(raw["state"]["name"]),
+            url=raw["url"],
+            assignee=raw.get("assignee", {}).get("name"),
+            labels=[l["name"] for l in raw.get("labels", {}).get("nodes", [])],
+            priority=raw.get("priority"),
+        )
+    # list_my_issues + format_branch_name follow the same pattern
+```
+
+#### GitHub Issues backend (new, skeleton)
+
+```python
+class GitHubIssuesProvider:
+    def __init__(self, config: dict):
+        self.repo = config["repo"]   # required: "owner/repo"
+
+    def get_issue(self, alias: str) -> Issue:
+        # alias like "#142" or "142" or "owner/repo#142"
+        issue_num = _parse_alias(alias, default_repo=self.repo)
+        raw = _gh_api_issue_get(self.repo, issue_num)
+        return Issue(
+            id=str(raw["id"]),
+            identifier=f"#{raw['number']}",
+            title=raw["title"],
+            description=raw.get("body"),
+            state=_map_gh_state(raw["state"]),  # "open" → "in_progress", "closed" → "done"
+            url=raw["html_url"],
+            assignee=raw["assignee"]["login"] if raw.get("assignee") else None,
+            labels=[l["name"] for l in raw.get("labels", [])],
+            priority=_priority_from_labels(raw.get("labels", [])),
+        )
+    # list_my_issues uses gh api search/issues?q=is:open+assignee:@me
+    # format_branch_name: "gh-142-fix-search" or similar
+```
+
+### 8. Future candidates (not v1)
+
+One paragraph each — named so future plans can adopt the pattern if it drops in cleanly, but **explicitly not specified or scheduled** here:
+
+- **Bot-author detection** — currently a hardcoded `author_type == "Bot"` substring check. Could be generalized into a "bot detector provider" with per-team rules. *No plan to make this a provider unless seamless during implementation of bot-comment-tracking.*
+- **CI providers** (GitHub Actions, CircleCI, Buildkite) — deferred to the CI-status plan. *No plan to make this a provider unless seamless during that plan's implementation.*
+- **Code-review platforms** (GitHub, GitLab, Bitbucket) — `gh` fallback works fine today. *No plan to make this a provider unless seamless.*
+- **IDE workspace formats** (VS Code `.code-workspace`, JetBrains `.idea/`, Cursor) — bootstrap plan deferred this. *No plan to make this a provider unless seamless.*
+- **Pre-commit frameworks** (pre-commit, husky, lefthook) — auto-detection works fine today. *No plan to make this a provider unless seamless.*
+
+**Effort cap on these candidates: < 5% of total architecture-doc effort.** If implementing any of the v1 issue-provider work surfaces a clean way to retrofit one of these, do it. Otherwise leave the existing handling alone.
+
+## Deliverable
+
+The doc itself, committed to `docs/architecture/providers.md`. Code lands in a subsequent plan (`docs/plans/issue-providers.md` will spec the first scaffold: refactor Linear + add GitHub Issues backend).
+
+## Verification
+
+The doc is reviewable as a design artifact. Once a future plan implements an issue-provider backend, that plan's PR description references the section it implements (e.g., "implements §2 contract + §7 Linear backend").
+
+## Out of scope
+
+- Per-repo issue-provider override (workspace-level only in v1)
+- Third-party provider entry points (bundled-only in v1)
+- Lifecycle automation methods (`update_issue_state`) — contract reserves the slot, first implementations raise `NotImplementedError`
+- Multi-provider in a single workspace (one provider per workspace; multi-tenant is a future plan)
+- Migrating PR/code-review integrations to the same pattern (different concern; out of scope)

--- a/docs/plans/providers-arch.md
+++ b/docs/plans/providers-arch.md
@@ -1,3 +1,10 @@
+---
+status: queued
+priority: P0
+effort: ~1d
+depends_on: []
+---
+
 # Architecture: provider-injection contract (issue providers)
 
 ## Why

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -6,7 +6,7 @@ This document is the canonical source-of-truth for canopy's pending work. It sup
 
 1. **Existing plans** I wrote in earlier sessions (eight plan files in `~/.claude/plans/canopy-*.md`).
 2. **New asks** from a real-world dogfood transcript (`~/projects/canopy/canopy-improvement-research.md`) that surfaced setup-propagation failures, bot-comment-tracking gaps, and per-workspace customization needs.
-3. **A scope refinement** for the provider-injection scaffolding pattern: scoped to issue providers (Phil's ask in [issue #5](https://github.com/ashmitb95/canopy/issues/5)), not a sweeping refactor.
+3. **A scope refinement** for the provider-injection scaffolding pattern: scoped to issue providers (per [issue #5](https://github.com/ashmitb95/canopy/issues/5)), not a sweeping refactor.
 
 What changed in this session:
 
@@ -163,7 +163,7 @@ First issue-provider scaffold       ← references the arch doc; refactors Linea
 ```
 
 Reasoning:
-- **Arch doc first.** Phil's ask is real and concrete; design before code prevents Linear-shaped APIs leaking into the contract.
+- **Arch doc first.** The provider-injection requirement is real and concrete; design before code prevents Linear-shaped APIs leaking into the contract.
 - **Doctor second.** Foundation for portability across machines (the dogfood transcript's load-bearing failure). The version handshake bits are preconditions for later upgrade detection.
 - **N3 before N2.** N2's bot classifier reads the `review_bots` list from N3's augments. Without N3, N2 falls back to hardcoded `author_type == "Bot"` — workable but less powerful.
 - **Historian after N2.** Historian's "comments resolved" log consumes N2's `bot_resolutions.json` + the temporal classifier's `likely_resolved` output. Without N2, historian would have to reimplement structured comment-resolution state. With N2 first, historian is a thin narrative layer on top.
@@ -189,11 +189,11 @@ Each of the three new items below is specced in this file (no separate plan file
 
 **Goal:** define the provider-injection pattern for issue providers, document the contract/discovery/config/wiring, and name (without specifying) the future candidate use cases.
 
-**Why first:** Phil's GitHub-issues ask in [issue #5](https://github.com/ashmitb95/canopy/issues/5) is concrete. We need the design pinned before any code lands so Linear-shaped assumptions don't bleed into the contract.
+**Why first:** the GitHub-issues requirement ([issue #5](https://github.com/ashmitb95/canopy/issues/5)) is concrete. We need the design pinned before any code lands so Linear-shaped assumptions don't bleed into the contract.
 
 **Doc structure:**
 
-1. **Motivation** — why provider injection (Phil's ask, future-proofing, multi-provider workspaces).
+1. **Motivation** — why provider injection (issue #5, future-proofing, multi-provider workspaces).
 2. **The contract** — Python protocol / abstract base for an issue provider:
    - `get_issue(alias: str) -> Issue` — returns canonical `Issue` shape (id, identifier, title, description, state, url, assignee, labels, priority)
    - `list_my_issues(limit: int = 50) -> list[Issue]`
@@ -505,7 +505,7 @@ Concrete sequence with rough effort estimates:
 3. **N3 augment skill** (§2.3) — ~2-3 days
 4. **N2 bot-comment tracking** (§2.4) — ~3 days
 5. **Historian** (§2.5) — ~5-6 days
-6. **First issue-provider scaffold** — Linear refactored into the contract, GitHub Issues backend per Phil — ~3-4 days
+6. **First issue-provider scaffold** — Linear refactored into the contract, GitHub Issues backend — ~3-4 days
 7. **Worktree bootstrap** ([3.3](~/.claude/plans/2026-04-28-canopy-worktree-bootstrap.md)) — ~2 days
 8. **Sidebar single-tree** ([3.5](~/.claude/plans/2026-04-26-canopy-sidebar-single-tree.md)) — ~1 day
 9. **Wave 2.4 `ship`** ([3.1](~/.claude/plans/2026-04-26-canopy-wave-2-4-ship.md)) — ~2-3 days
@@ -514,7 +514,7 @@ Concrete sequence with rough effort estimates:
 12. **Action drawer** ([3.6](~/.claude/plans/2026-04-26-canopy-action-drawer.md)) — ~3-4 days
 13. **Cross-feature conflicts** ([3.7](~/.claude/plans/2026-04-28-canopy-cross-feature-conflicts.md)) — ~1-2 days
 
-Estimated total: ~30-36 days of focused engineering. The first 6 items (~17-20 days) deliver the dogfood-failure recoveries, the new agent-facing customization surface, cross-session feature memory, and the issue-provider scaffold Phil asked for.
+Estimated total: ~30-36 days of focused engineering. The first 6 items (~17-20 days) deliver the dogfood-failure recoveries, the new agent-facing customization surface, cross-session feature memory, and the issue-provider scaffold.
 
 ---
 
@@ -624,14 +624,14 @@ Tracking lives in [INDEX.md](INDEX.md), not GitHub issues. Each plan file's YAML
 
 - The plans are already detailed and reviewable as files. Duplicating into issue bodies adds maintenance overhead.
 - The user is mostly solo on canopy today; full GitHub Issues machinery (labels, templates, multi-issue dependency graph) is overkill.
-- Contributors who want to comment on the design can do it via PR review on the plan file. INDEX.md aggregates status; the file is the spec.
+- The plan file is the spec; INDEX.md aggregates status. Future contributors (when they appear) can comment on the design via PR review on the plan file.
 
 **Workflow:**
 
 1. When a milestone starts: update its checkbox/glyph in INDEX.md (🟦 → 🟨); update its plan's frontmatter (`status: queued` → `in-progress`).
 2. When it ships: ✅ in INDEX.md, `status: shipped` in frontmatter, move the plan to `archive/` with a date.
 3. Plan amendments happen via PR on the plan file itself.
-4. If multi-contributor coordination becomes needed later (more than just Phil's PR), revisit issue tracking — the in-tree approach is the floor, not the ceiling.
+4. If multi-contributor coordination becomes needed later, revisit issue tracking — the in-tree approach is the floor, not the ceiling.
 
 ## What changes in `~/.claude/plans/` after this is approved
 

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -616,160 +616,22 @@ Files touched by multiple sub-plans / artifacts. Listed once here so executors o
 
 ---
 
-## Section 9 — GitHub Issues tracking
+## Section 9 — Tracking via in-tree docs
 
-**Goal:** every pending plan becomes a trackable GitHub issue on `ashmitb95/canopy`. Plan files move in-tree under `docs/plans/` so contributors (Phil and others) can comment on the plans themselves; issues handle status, priority, dependencies, and discussion.
+Tracking lives in [INDEX.md](INDEX.md), not GitHub issues. Each plan file's YAML frontmatter declares its `status` / `priority` / `effort` / `depends_on`; INDEX.md is the rolled-up epic dashboard with a checkbox per milestone.
 
-### 9.1 — Plan file migration (in-tree)
+**Why in-tree docs instead of issues:**
 
-| Current location | New location | Notes |
-|---|---|---|
-| `~/.claude/plans/2026-04-26-canopy-action-drawer.md` | `docs/plans/action-drawer.md` | rename: drop date prefix |
-| `~/.claude/plans/2026-04-26-canopy-sidebar-single-tree.md` | `docs/plans/sidebar-single-tree.md` | |
-| `~/.claude/plans/2026-04-26-canopy-wave-2-4-ship.md` | `docs/plans/wave-2-4-ship.md` | |
-| `~/.claude/plans/2026-04-26-canopy-wave-4-draft-replies.md` | `docs/plans/wave-4-draft-replies.md` | |
-| `~/.claude/plans/2026-04-28-canopy-ci-status.md` | `docs/plans/ci-status.md` | |
-| `~/.claude/plans/2026-04-28-canopy-cross-feature-conflicts.md` | `docs/plans/cross-feature-conflicts.md` | |
-| `~/.claude/plans/2026-04-28-canopy-doctor.md` | `docs/plans/doctor.md` | append §2.2 contents (install-staleness categories) before publishing |
-| `~/.claude/plans/2026-04-28-canopy-worktree-bootstrap.md` | `docs/plans/worktree-bootstrap.md` | |
-| `~/.claude/plans/2026-04-26-canopy-skipped-phases.md` | (do not migrate) | superseded by this roadmap |
-| `~/.claude/plans/2026-04-26-canopy-wave-2-3-commit-push.md` | `docs/plans/archive/wave-2-3-commit-push.md` | shipped; archive for history |
-| `~/.claude/plans/lets-plaan-all-3-melodic-cloud.md` (this file) | `docs/plans/roadmap.md` | the in-tree canonical roadmap |
+- The plans are already detailed and reviewable as files. Duplicating into issue bodies adds maintenance overhead.
+- The user is mostly solo on canopy today; full GitHub Issues machinery (labels, templates, multi-issue dependency graph) is overkill.
+- Contributors who want to comment on the design can do it via PR review on the plan file. INDEX.md aggregates status; the file is the spec.
 
-The four new artifacts embedded in this roadmap (Sections 2.1–2.5) get extracted into their own `docs/plans/<name>.md` files at execution time (one per artifact):
+**Workflow:**
 
-- `docs/plans/providers-arch.md` (from §2.1)
-- `docs/plans/augments.md` (from §2.3 — N3)
-- `docs/plans/bot-tracking.md` (from §2.4 — N2)
-- `docs/plans/historian.md` (from §2.5)
-
-### 9.2 — Issue template
-
-Add `.github/ISSUE_TEMPLATE/plan.yml`:
-
-```yaml
-name: Plan tracking
-description: Track a planned feature against its in-repo plan file
-title: "[plan] "
-labels: ["plan-tracker"]
-body:
-  - type: input
-    id: plan-file
-    attributes:
-      label: Plan file
-      description: "Path to the in-repo plan file"
-      placeholder: "docs/plans/<name>.md"
-    validations:
-      required: true
-  - type: dropdown
-    id: priority
-    attributes:
-      label: Priority
-      options: [P0 (urgent), P1 (next up), P2 (queued), P3 (nice-to-have)]
-  - type: input
-    id: effort
-    attributes:
-      label: Effort estimate
-      placeholder: "~N days"
-  - type: input
-    id: depends-on
-    attributes:
-      label: Depends on
-      placeholder: "#<issue-number> (if any)"
-  - type: textarea
-    id: summary
-    attributes:
-      label: Summary
-      description: "2-3 sentences: what this delivers and why"
-    validations:
-      required: true
-  - type: textarea
-    id: acceptance
-    attributes:
-      label: Acceptance criteria
-      placeholder: "- [ ] item\n- [ ] item"
-    validations:
-      required: true
-  - type: textarea
-    id: out-of-scope
-    attributes:
-      label: Out of scope
-```
-
-### 9.3 — Labels to create
-
-Via `gh label create` (one-shot script `scripts/setup-labels.sh`):
-
-| Label | Color | Description |
-|---|---|---|
-| `P0` | `#b60205` | urgent |
-| `P1` | `#d93f0b` | next up |
-| `P2` | `#fbca04` | queued |
-| `P3` | `#0e8a16` | nice-to-have |
-| `plan-tracker` | `#5319e7` | tracks an in-repo plan file |
-| `cli` | `#1d76db` | scope: CLI |
-| `mcp` | `#1d76db` | scope: MCP server |
-| `backend` | `#1d76db` | scope: Python backend |
-| `extension` | `#1d76db` | scope: VSCode extension |
-| `docs` | `#0075ca` | scope: documentation |
-| `tests` | `#0075ca` | scope: tests |
-| `blocked` | `#000000` | status: blocked |
-| `in-progress` | `#fbca04` | status: in flight |
-| `ready-for-review` | `#0e8a16` | status: PR open |
-
-### 9.4 — Issues to create (13 sub-issues + 1 parent epic)
-
-| # | Issue title | Plan file | Priority | Scope labels | Depends on |
-|---|---|---|---|---|---|
-| Epic | Canopy roadmap 2026-05 — agent surface + dogfood-failure recoveries | docs/plans/roadmap.md | P0 | plan-tracker | n/a |
-| 1 | Architecture: provider injection contract (issue providers) | docs/plans/providers-arch.md | P0 | plan-tracker, docs | (epic) |
-| 2 | canopy doctor — state-file integrity + install-staleness recovery | docs/plans/doctor.md | P0 | plan-tracker, cli, mcp, backend | (epic) |
-| 3 | Augment skill — per-workspace customization (preflight_cmd, review_bots, test_cmd) | docs/plans/augments.md | P1 | plan-tracker, mcp, cli, backend | #2 |
-| 4 | Bot-comment tracking — `commit --address`, awaiting_bot_resolution state | docs/plans/bot-tracking.md | P1 | plan-tracker, mcp, cli, backend | #3 |
-| 5 | Historian — cross-session feature memory | docs/plans/historian.md | P1 | plan-tracker, mcp, backend | #4 |
-| 6 | Issue-provider scaffold — Linear refactor + GitHub Issues backend | docs/plans/issue-providers.md | P1 | plan-tracker, mcp, backend | #1 |
-| 7 | Worktree bootstrap — env-file copy, dep install, IDE workspace gen | docs/plans/worktree-bootstrap.md | P2 | plan-tracker, mcp, cli, backend | #2 |
-| 8 | Extension sidebar — collapse 5 trees → 1 unified tree | docs/plans/sidebar-single-tree.md | P2 | plan-tracker, extension | n/a |
-| 9 | Wave 2.4 — `canopy ship` (commit + push + open PR) | docs/plans/wave-2-4-ship.md | P2 | plan-tracker, mcp, cli, backend | #4 |
-| 10 | Wave 4 — `draft_replies` (auto-draft addressed-thread replies) | docs/plans/wave-4-draft-replies.md | P2 | plan-tracker, mcp, backend | #4 |
-| 11 | CI status integration — `awaiting_ci` state + `pr_checks` MCP tool | docs/plans/ci-status.md | P2 | plan-tracker, mcp, backend | #4 |
-| 12 | Extension action drawer — dashboard right-rail rebuild (~16 actions) | docs/plans/action-drawer.md | P3 | plan-tracker, extension | #9, #10 |
-| 13 | `canopy conflicts` — cross-feature file-overlap detection | docs/plans/cross-feature-conflicts.md | P3 | plan-tracker, mcp, cli, backend | n/a |
-
-### 9.5 — Per-issue body generation
-
-Each issue body is a 5-section condensation derived from the plan file:
-
-1. **Plan file link** (1 line, top of body): `**Plan:** [docs/plans/<name>.md](docs/plans/<name>.md)`
-2. **Metadata** (4 lines): Status / Priority / Effort / Depends on (from the table in 9.4)
-3. **Summary** (2–3 sentences, from the plan's "Goal" section)
-4. **Acceptance criteria** (5–8 checkbox items derived from the plan's "Verification" section, rephrased as user-visible outcomes)
-5. **Out of scope** (3–5 bullets from the plan's "Out of scope" / "Non-goals" section)
-
-The plan file remains the deeper execution reference; the issue body is the executive summary + tracking checklist.
-
-### 9.6 — Implementation steps (when execution begins)
-
-1. Create `docs/plans/` directory and `docs/plans/archive/` subdirectory in the canopy repo.
-2. Move/rename the 8 active plans + 1 archived plan per the table in 9.1. Update the in-tree doctor plan with §2.2 contents (install-staleness categories + version handshake additions).
-3. Extract the four embedded artifacts (Sections 2.1–2.5) into their own `docs/plans/<name>.md` files.
-4. Move this roadmap to `docs/plans/roadmap.md`.
-5. Commit the plan migration in one atomic commit on a `chore/plan-migration` branch; PR to main.
-6. Add `.github/ISSUE_TEMPLATE/plan.yml` and `scripts/setup-labels.sh`. Run the label-setup script.
-7. Create the parent epic issue first; capture its issue number.
-8. Create each of the 13 sub-issues. Reference the epic in each via "Part of #<epic-number>". Use the priority + scope labels per the table.
-9. Edit the parent epic body to include a checklist of all 13 sub-issues.
-10. Going forward: when work starts on a plan, label its issue `in-progress`; when its PR opens, label `ready-for-review`; when merged, close the issue.
-
-### 9.7 — Workflow conventions after migration
-
-- **Discussion happens on the issue**, not the plan file. The plan file is the spec; the issue is the tracker.
-- **Plan amendments happen on the plan file** via PR. The PR description references the issue.
-- **Cross-issue dependencies are surfaced via the `Depends on:` line in the body**, not via labels. Status-board logic can still parse it.
-- **Sub-issues link to the epic** via "Part of #<epic-number>" in the body. Epic body has the checklist.
-- **Closing the epic** requires all sub-issues closed.
-
----
+1. When a milestone starts: update its checkbox/glyph in INDEX.md (🟦 → 🟨); update its plan's frontmatter (`status: queued` → `in-progress`).
+2. When it ships: ✅ in INDEX.md, `status: shipped` in frontmatter, move the plan to `archive/` with a date.
+3. Plan amendments happen via PR on the plan file itself.
+4. If multi-contributor coordination becomes needed later (more than just Phil's PR), revisit issue tracking — the in-tree approach is the floor, not the ceiling.
 
 ## What changes in `~/.claude/plans/` after this is approved
 

--- a/docs/plans/roadmap.md
+++ b/docs/plans/roadmap.md
@@ -1,0 +1,781 @@
+# Canopy — Execution Roadmap (2026-05-02)
+
+## Context
+
+This document is the canonical source-of-truth for canopy's pending work. It supersedes the prior tracker at `~/.claude/plans/2026-04-26-canopy-skipped-phases.md`, consolidating:
+
+1. **Existing plans** I wrote in earlier sessions (eight plan files in `~/.claude/plans/canopy-*.md`).
+2. **New asks** from a real-world dogfood transcript (`~/projects/canopy/canopy-improvement-research.md`) that surfaced setup-propagation failures, bot-comment-tracking gaps, and per-workspace customization needs.
+3. **A scope refinement** for the provider-injection scaffolding pattern: scoped to issue providers (Phil's ask in [issue #5](https://github.com/ashmitb95/canopy/issues/5)), not a sweeping refactor.
+
+What changed in this session:
+
+- **N1 (`canopy upgrade`) is absorbed into the existing doctor plan** — they're orthogonal in scope but identical in shape (Issue / repair pattern). One unified `canopy doctor` command. Validated by reasoning through the Plan agent's output + the user's instinct that doctor is the more robust design.
+- **A provider-injection architecture document** is now a planned artifact, separate from any sub-plan. Lives at `docs/architecture/providers.md`. Scoped to issue providers in v1; future candidate use cases (bot-author / CI / code-review / IDE workspace formats) are *named but not specified* — they only adopt the pattern if it drops in seamlessly.
+- **Three new sub-plans** added to the queue: augment skill (N3), bot-comment tracking (N2), and historian (cross-session feature memory). All file-by-file specced below.
+- **Sequencing locked**: arch doc → doctor → augments (N3) → bot-tracking (N2) → historian → first issue-provider scaffold. Other existing plans (worktree-bootstrap, sidebar-single-tree, ship, draft_replies, ci-status, action-drawer, conflicts) slot in afterward; their order remains as in their individual plan files.
+
+---
+
+## Section 0 — Full pending inventory
+
+Every plan currently in `~/.claude/plans/`:
+
+| # | File | Scope | Status | Priority | Depends on |
+|---|------|-------|--------|----------|------------|
+| 1 | `2026-04-26-canopy-skipped-phases.md` | Meta tracker for skipped Wave 2.3/2.4/4 backends | superseded by this doc | n/a | n/a |
+| 2 | `2026-04-26-canopy-wave-2-3-commit-push.md` | `commit` + `push` MCP tools | ✅ shipped | n/a | n/a |
+| 3 | `2026-04-26-canopy-wave-2-4-ship.md` | `ship` MCP tool (commit + push + open PRs) | pending | medium | wave-2-3 (shipped) |
+| 4 | `2026-04-26-canopy-wave-4-draft-replies.md` | `draft_replies` MCP tool | pending | medium | review classifier (shipped) |
+| 5 | `2026-04-26-canopy-sidebar-single-tree.md` | Extension sidebar collapse to single tree | pending | low (UI only, independent) | none |
+| 6 | `2026-04-26-canopy-action-drawer.md` | Extension dashboard right-rail rebuild, ~16 wired actions | pending | low (depends on backends) | wave-2-4 + wave-4 |
+| 7 | `2026-04-28-canopy-doctor.md` | State-file integrity check + repair | pending | **HIGH** | none — earliest foundation |
+| 8 | `2026-04-28-canopy-ci-status.md` | CI status in `feature_state` + `awaiting_ci` state + `pr_checks` MCP tool | pending | medium | none |
+| 9 | `2026-04-28-canopy-cross-feature-conflicts.md` | `canopy conflicts` cross-feature file-overlap | pending | LOW (nice-to-have) | none |
+| 10 | `2026-04-28-canopy-worktree-bootstrap.md` | Env-file copy + dep install + IDE workspace gen on worktree create | pending | medium | none |
+| 11 | **THIS FILE** | Roadmap + 3 new sub-plans + arch-doc spec | drafting | HIGH | n/a |
+
+The four new artifacts embedded in this file (no separate plan files written for them — they live here so the roadmap stays consolidated):
+
+- **Architecture doc — provider injection (issue providers scoped)** → produces `docs/architecture/providers.md` as a deliverable
+- **Augment skill (N3)** → per-workspace customization (preflight_cmd, test_cmd, review_bots) + new `augment-canopy` skill
+- **Bot-comment tracking (N2)** → distinguish bot vs human review threads, `commit --address`, `awaiting_bot_resolution` state
+- **Historian (cross-session feature memory)** → `.canopy/memory/<feature>.md` persistent log of decisions, events, comment activity, PR context. Auto-read on `canopy switch`. Eliminates the agent's "re-derive everything every session" tax.
+
+---
+
+## Section 1 — Cross-cutting decisions
+
+These apply across multiple sub-plans. Documented here once; sub-plan sections reference by anchor.
+
+### 1.1 — Doctor absorbs `canopy upgrade` categories
+
+The existing doctor plan covers workspace state-file integrity (heads.json stale, orphan worktrees, missing hooks, etc.). The proposed-but-now-merged "canopy upgrade" idea covers machine-level artifact staleness (CLI version, MCP version, vsix cleanup, missing skill, missing `.mcp.json` entry, version handshake).
+
+**Decision:** these are the same kind of work — diagnose, classify, repair. One `canopy doctor` command, growing taxonomy. Severity tiers (`info` / `warn` / `error`) handle the urgency distinction; `--fix=<category>` opts into specific repairs; reload-required repairs return `BlockerError(code='reload_required', fix_action='reload window')` rather than silent UX bumps.
+
+The doctor plan ([`2026-04-28-canopy-doctor.md`](~/.claude/plans/2026-04-28-canopy-doctor.md)) is extended with six new categories — see Section 3 below for the additions.
+
+### 1.2 — Architecture doc for provider injection (issue providers scoped)
+
+A separate engineering reference at `docs/architecture/providers.md`. Defines the contract / discovery / configuration / DI wiring for **issue providers** specifically (Linear, GitHub Issues, JIRA shape).
+
+Future candidate use cases (bot-author detection, CI providers, code-review platforms, IDE workspace formats) are *named in the doc but not specified*. They adopt the pattern only if it drops in seamlessly during implementation; otherwise their current handling stays.
+
+**Effort cap on the non-issue-provider candidates: < 5% of total architecture-doc effort.**
+
+### 1.3 — State machine: `awaiting_bot_resolution` placement (N2)
+
+Insert between `awaiting_review` and `approved`. Do **not** gate `approved` — human approval is the merge gate; bot nits are a side-channel.
+
+```
+drifted > needs_work (human) > in_progress > ready_to_commit
+       > ready_to_push > awaiting_bot_resolution > awaiting_review
+       > approved > no_prs
+```
+
+Trigger: no human `CHANGES_REQUESTED`, no actionable human threads, ≥1 actionable bot thread, PR not yet `APPROVED`. If approved + bot threads still open: state stays `approved`; "address bot comments" is a *secondary* CTA in `next_actions`.
+
+`_per_repo_facts` splits `actionable_count` → `actionable_human_count` + `actionable_bot_count` (using the existing `author_type` field at `integrations/github.py:537`).
+
+### 1.4 — Augment config schema (N3)
+
+Two-tier: workspace defaults + per-repo override.
+
+```toml
+[augments]
+preflight_cmd = "make check"
+test_cmd = "pytest"
+review_bots = ["coderabbit", "korbit"]   # case-insensitive author substring match
+
+[[repos]]
+name = "api"
+augments = { preflight_cmd = "uv run pytest tests/fast" }
+```
+
+Resolution helper (new — `src/canopy/actions/augments.py`):
+
+```python
+def repo_augments(workspace: WorkspaceConfig, repo_name: str) -> dict[str, Any]:
+    """Merge workspace [augments] defaults with per-repo override. Per-repo wins."""
+```
+
+Three call sites consume this in v1: `precommit.py:run_precommit` (preflight_cmd), `actions/feature_state.py:_per_repo_facts` (review_bots filter), and a future `canopy test` command (test_cmd, not v1).
+
+The augment config is **not reachable via `canopy config` CLI** in v1 — `cmd_config` is flat-only. The `augment-canopy` skill mutates canopy.toml directly via parse → modify → write atomic.
+
+### 1.5 — Skill packaging: one installer, multiple skills
+
+Reorganize bundled skills:
+
+```
+src/canopy/agent_setup/
+├── __init__.py
+└── skills/
+    ├── using-canopy/SKILL.md       # existing, moved from agent_setup/skill.md
+    └── augment-canopy/SKILL.md     # new in N3
+```
+
+Generalize the installer:
+
+```python
+def install_skill(name: str = "using-canopy", *, reinstall: bool = False) -> dict:
+    src = _SKILLS_DIR / name / "SKILL.md"
+    dst = _USER_SKILLS_DIR / name / "SKILL.md"
+    # ...existing idempotency logic
+```
+
+`setup_agent` accepts a list:
+
+```python
+def setup_agent(workspace_root, *, skills: tuple[str, ...] = ("using-canopy",), do_mcp=True, reinstall=False) -> dict:
+    ...
+```
+
+Doctor's diagnostic categories iterate the same list to detect missing/stale skills.
+
+### 1.6 — Version handshake (doctor expansion)
+
+Single source of truth: `src/canopy/__init__.py:__version__`. Three reporting layers:
+
+- **CLI:** `canopy --version` (argparse `version` action)
+- **MCP server:** new `version()` MCP tool returning `{cli_version, mcp_version, schema_version}`. Schema version starts at `"1"`, bumps on canopy.toml schema changes (independent of package version).
+- **Extension:** at MCP startup, calls `version()` once. Logs warning on minor mismatch; refuses activation on major mismatch with toast offering `canopy doctor --fix`.
+
+Doctor reads each binary's `--version` output to determine staleness.
+
+### 1.7 — Sequencing rationale
+
+```
+arch doc (issue providers)         ← design reference; doesn't ship code
+   ↓
+doctor (extended w/ install-staleness categories + version handshake)
+   ↓
+N3 augment skill                    ← independent, small, seeds review_bots for N2
+   ↓
+N2 bot-comment tracking             ← uses review_bots from N3, awaiting_bot_resolution state
+   ↓
+Historian                           ← consumes N2's bot_resolutions + classifier output; cross-session memory
+   ↓
+First issue-provider scaffold       ← references the arch doc; refactors Linear into the contract; adds GitHub Issues backend
+   ↓
+[existing plans pick up: worktree-bootstrap, ci-status, ship, draft_replies, etc.]
+```
+
+Reasoning:
+- **Arch doc first.** Phil's ask is real and concrete; design before code prevents Linear-shaped APIs leaking into the contract.
+- **Doctor second.** Foundation for portability across machines (the dogfood transcript's load-bearing failure). The version handshake bits are preconditions for later upgrade detection.
+- **N3 before N2.** N2's bot classifier reads the `review_bots` list from N3's augments. Without N3, N2 falls back to hardcoded `author_type == "Bot"` — workable but less powerful.
+- **Historian after N2.** Historian's "comments resolved" log consumes N2's `bot_resolutions.json` + the temporal classifier's `likely_resolved` output. Without N2, historian would have to reimplement structured comment-resolution state. With N2 first, historian is a thin narrative layer on top.
+- **Issue-provider scaffold last** in this group. The arch doc + doctor + augment + historian foundations make the implementation cleaner.
+
+### 1.8 — Historian capture mechanism (Historian)
+
+Hybrid: explicit MCP tool calls (primary) + Stop-hook tail-parse (backup).
+
+- **Primary: explicit tool calls.** Skill teaches the agent to call `mcp__canopy__historian_decide(feature, decisions=[...])` after committing to an approach (after a commit, after a pivot, on pause). Reliable; structured input validated by the MCP protocol.
+- **Backup: Stop-hook tail-parse.** Skill teaches: at end of turn where you decided something but didn't call the tool, emit `<historian-decisions>[{title, rationale}, ...]</historian-decisions>` in the response. Stop hook scans the last assistant message; parses; writes any decisions not already captured (deduped by title).
+- **Rejected: extra-prompt round-trip.** A hook that fires after commit and asks the agent "any decisions worth recording?" wastes an LLM turn given the tool-call primitive exists.
+
+The hybrid handles two failure modes: (a) agent forgets to call the tool but mentions the decision in their response (tail-parse rescue), (b) agent does both (deduped). Format-only would have ~5–10% silent gaps in long sessions; tool-only would miss free-text decisions that didn't trigger an explicit call. The hybrid pushes silent-gap rate to near zero.
+
+---
+
+## Section 2 — New artifacts this roadmap introduces
+
+Each of the three new items below is specced in this file (no separate plan file). Each can be split out into its own plan file when execution starts, if a fresh-context session prefers it.
+
+### 2.1 — Architecture doc: `docs/architecture/providers.md`
+
+**Goal:** define the provider-injection pattern for issue providers, document the contract/discovery/config/wiring, and name (without specifying) the future candidate use cases.
+
+**Why first:** Phil's GitHub-issues ask in [issue #5](https://github.com/ashmitb95/canopy/issues/5) is concrete. We need the design pinned before any code lands so Linear-shaped assumptions don't bleed into the contract.
+
+**Doc structure:**
+
+1. **Motivation** — why provider injection (Phil's ask, future-proofing, multi-provider workspaces).
+2. **The contract** — Python protocol / abstract base for an issue provider:
+   - `get_issue(alias: str) -> Issue` — returns canonical `Issue` shape (id, identifier, title, description, state, url, assignee, labels, priority)
+   - `list_my_issues(limit: int = 50) -> list[Issue]`
+   - `format_branch_name(issue_id: str, title: str | None, custom: str | None) -> str` — provider-specific slug rules
+   - Optional: `update_issue_state(alias: str, new_state: str) -> None` for lifecycle automation (deferred to a future plan; contract reserves the slot).
+3. **Discovery** — how canopy finds providers:
+   - **v1: bundled.** Canopy ships `canopy.providers.linear` and `canopy.providers.github_issues` as built-in modules.
+   - **Future: entry points.** Third-party providers register via `pyproject.toml` entry points (`canopy.providers` group). Not v1.
+4. **Configuration** — how the user/workspace picks a provider:
+   - canopy.toml top-level `[issue_provider]` block: `name = "linear"` or `"github_issues"`, plus provider-specific config (e.g., `linear.api_key_env = "LINEAR_API_KEY"`, `github_issues.repo = "owner/repo"`).
+   - Per-repo override possible via `[[repos]] issue_provider = {...}` for the rare case a single workspace has repos using different trackers (deferred — workspace-level only in v1).
+5. **DI wiring** — how the action layer obtains the provider instance:
+   - New module `src/canopy/providers/__init__.py` exposes `get_issue_provider(workspace) -> IssueProvider`.
+   - Cached per-workspace; constructed lazily on first access.
+   - Action code calls `get_issue_provider(ws).get_issue(alias)` instead of `linear.get_issue(workspace.config.root, alias)`.
+6. **Backward compatibility** — existing code paths:
+   - Current `integrations/linear.py` becomes the Linear backend implementing the contract.
+   - Current `integrations/github.py` PR/branch logic stays separate (review-platform concern, not issue-provider concern).
+   - Existing `mcp__canopy__linear_get_issue` MCP tool keeps working (deprecated alias for `mcp__canopy__issue_get` once the new tool ships).
+7. **Examples** — fully worked Linear backend + skeleton GitHub Issues backend.
+8. **Future candidates (not v1)** — one paragraph per:
+   - Bot-author detection (currently hardcoded `author_type == "Bot"` substring; *no plan to make a provider unless seamless*)
+   - CI providers (deferred to ci-status plan; *no plan to make a provider unless seamless*)
+   - Code-review platforms (gh fallback works fine today; *no plan to make a provider unless seamless*)
+   - IDE workspace formats (bootstrap plan deferred; *no plan to make a provider unless seamless*)
+   - Pre-commit frameworks (auto-detection works fine today; *no plan to make a provider unless seamless*)
+
+**Deliverable:** the doc itself. Code lands in subsequent plans.
+
+**Verification:** the doc is reviewable as a design artifact. Once a future plan implements an issue-provider backend, that plan's PR description references the section it implements.
+
+### 2.2 — Doctor extension: install-staleness categories + version handshake
+
+**Goal:** extend the existing doctor plan with six new diagnostic categories and the version handshake. Keeps doctor as the single recovery primitive.
+
+**New diagnostic categories** (additions to the doctor plan's matrix):
+
+| Code | Severity | Detection | Repair |
+|---|---|---|---|
+| `cli_stale` | warn | `canopy --version` < `__version__` | re-pip-install or re-pipx-install (detected from install method) |
+| `mcp_stale` | error | MCP `version()` returns < `__version__`, or tool missing entirely | reinstall venv via existing `runInstallBackend` pattern |
+| `mcp_missing_in_workspace` | error | `.mcp.json` lacks canopy entry, or `CANOPY_ROOT` mismatched | `install_mcp(workspace_root, reinstall=True)` |
+| `skill_missing` | warn | no SKILL.md at `~/.claude/skills/<name>/` for any skill in the configured list | `install_skill(name)` for each missing |
+| `skill_stale` | warn | byte-compare against bundled source returns mismatch | `install_skill(name, reinstall=True)` |
+| `vsix_duplicates` | info | multiple `singularityinc.canopy-*` dirs in `~/.vscode/extensions/` | report; `--clean-vsix` flag removes non-current versions |
+
+**Version handshake** (per cross-cutting 1.6):
+- New constant `__version__` in `src/canopy/__init__.py` (sourced from `pyproject.toml`).
+- New CLI: `canopy --version`.
+- New MCP tool: `version()` returns `{cli_version, mcp_version, schema_version}`.
+- Extension calls `version()` at MCP startup; mismatch handling per 1.6.
+
+**Files to touch (additions to doctor plan):**
+
+- `src/canopy/__init__.py` — `__version__` constant
+- `src/canopy/cli/main.py` — `--version` argparse action; `cmd_doctor` extended to call install-staleness checks
+- `src/canopy/mcp/server.py` — new `version()` tool
+- `src/canopy/actions/doctor.py` — six new check functions, six new repair functions
+- `vscode-extension/src/canopyClient.ts` — version handshake on MCP startup
+- `tests/test_doctor.py` — extend with install-staleness fixtures
+
+**Deliverable:** doctor with 15 diagnostic codes (9 existing + 6 new), single command, severity-tiered output.
+
+### 2.3 — N3 augment skill: per-workspace customization
+
+(Detailed spec — this becomes the source-of-truth when execution starts; can be extracted to its own plan file then if preferred.)
+
+**Goal:** per-workspace customization for canopy operations that vary by team/codebase: which preflight command runs, which test command runs, which authors count as bots. Stored in canopy.toml. Set via the `augment-canopy` skill.
+
+**Schema additions** (per cross-cutting 1.4):
+- `[augments]` workspace-level table with `preflight_cmd`, `test_cmd`, `review_bots`
+- `[[repos]] augments = {...}` per-repo override
+- `repo_augments(workspace, repo_name)` resolver in new `src/canopy/actions/augments.py`
+
+**New skill:** `src/canopy/agent_setup/skills/augment-canopy/SKILL.md`. Loaded only when user is actively customizing. Teaches the agent:
+- When to suggest customization ("user says X uses Y for Z")
+- The TOML schema (workspace defaults vs per-repo overrides)
+- How to mutate canopy.toml safely (read → tomli/tomllib parse → modify → atomic write)
+- Augment changes are picked up on next operation (no canopy restart required)
+
+**Wiring change:** `integrations/precommit.py:run_precommit(repo_path, repo_config: RepoConfig | None = None)`. Three call sites pass `repo_config`:
+- `features/coordinator.py:1035` (review_prep path)
+- `mcp/server.py:563` (preflight MCP tool)
+- `cli/main.py:1126` (cmd_preflight)
+
+When `repo_config.augments.preflight_cmd` is set, the override runs; otherwise existing auto-detection (pre-commit framework or git hook) applies.
+
+**Skill packaging refactor** (per cross-cutting 1.5):
+- Move `src/canopy/agent_setup/skill.md` → `src/canopy/agent_setup/skills/using-canopy/SKILL.md`
+- Generalize `install_skill(name="using-canopy", *, reinstall=False)`
+- `setup_agent(workspace_root, *, skills=("using-canopy",), do_mcp=True, reinstall=False)`
+- Doctor (2.2) iterates the configured skill list
+
+**Files to touch:**
+
+- `src/canopy/workspace/config.py` — `WorkspaceConfig.augments: dict[str, Any]`, `RepoConfig.augments: dict[str, str]`, parser updates
+- **New:** `src/canopy/actions/augments.py` — `repo_augments()` resolver, `bot_authors()` helper
+- `src/canopy/integrations/precommit.py` — `run_precommit` signature change
+- `src/canopy/features/coordinator.py`, `src/canopy/mcp/server.py`, `src/canopy/cli/main.py` — three call-site updates
+- `src/canopy/agent_setup/__init__.py` — skill packaging refactor; `install_skill` + `setup_agent` generalization
+- **Move:** `src/canopy/agent_setup/skill.md` → `src/canopy/agent_setup/skills/using-canopy/SKILL.md`
+- **New:** `src/canopy/agent_setup/skills/augment-canopy/SKILL.md` (~3-4 KB content, includes worked example of "user says X → agent edits canopy.toml")
+- `tests/test_augments.py` (new), `tests/test_config.py` (extended), `tests/test_precommit.py` (extended)
+- `docs/workspace.md` — document `[augments]` block + per-repo override
+- `docs/agents.md` — reference the augment skill
+
+**Implementation order:**
+
+1. Extend `RepoConfig` + `WorkspaceConfig` dataclasses + parser. Tests pass with empty defaults (backward-compat).
+2. New `repo_augments()` resolver. Pure function; unit-tested.
+3. Extend `run_precommit()` signature. Update three call sites. Existing tests pass with default `None`.
+4. Reorganize skill packaging. Update `cmd_init` and `cmd_setup_agent` callers.
+5. Write `augment-canopy/SKILL.md`.
+6. `canopy setup-agent --skill augment-canopy` flag for opt-in install.
+
+**Verification:**
+- Unit: resolver merges; per-repo wins on collision; missing keys return None/empty.
+- Unit: `run_precommit` with custom `preflight_cmd` runs the override; with None, auto-detect still works.
+- Integration: workspace with `augments.preflight_cmd = "echo ok && exit 0"` → `canopy preflight` returns success.
+- Manual: agent reads "this workspace uses ruff for preflight" → invokes augment-canopy skill → canopy.toml updated → `canopy preflight` runs ruff.
+
+### 2.4 — N2 bot-comment tracking + `commit --address`
+
+(Detailed spec — same treatment as N3.)
+
+**Goal:** treat bot review comments (CodeRabbit, Korbit, Cubic, Copilot) as a distinct workflow concern. Track per-comment "addressed by which commit." Provide a rollup ("all bot comments resolved?") and a `commit --address <comment-id>` flag with auto-formatted commit messages.
+
+**Data model changes:**
+
+- `integrations/github.py:_normalize_comments` (line 537): include `id` field — `"id": c.get("id")`. Backward-compat.
+- **New persistent state:** `<workspace>/.canopy/state/bot_resolutions.json`. Append-only mapping `{<comment_id>: {feature, repo, commit_sha, addressed_at, comment_title}}`.
+- `actions/feature_state.py:_per_repo_facts`: split `actionable_count` → `actionable_human_count` + `actionable_bot_count`. Bot determined by `author_type == "Bot"` AND author matching `bot_authors(workspace)` (uses N3's `review_bots` augment).
+- `actions/feature_state.py:_decide_state`: insert `awaiting_bot_resolution` per cross-cutting 1.3.
+
+**New CLI/MCP surface:**
+
+- `canopy commit --address <comment-id>`:
+  - Resolves `<comment-id>` against the feature's actionable bot threads (via `_per_repo_facts`)
+  - Looks up comment `body` (truncated first sentence) and `url`
+  - Auto-formats: `<user message>\n\nAddresses bot comment: "<title-fragment>" (<url>)`. If no `--message`, uses just the auto-line.
+  - On success, appends to `bot_resolutions.json`
+  - Returns existing per-repo result dict + `addressed_comment_id` field
+- `canopy bot-status [--feature <X>] [--unresolved-only]`:
+  - Per-PR rollup: total bot comments, resolved, unresolved
+  - `--json` returns structured dict (used by agent + dashboard)
+- `mcp__canopy__bot_comments_status(feature)`: same shape as CLI `--json`, returns `{feature, repos: {<repo>: {pr_number, total, resolved, unresolved, threads}}, all_resolved: bool}`
+
+**Files to touch:**
+
+- `src/canopy/integrations/github.py` (line 537) — add `id` field
+- `src/canopy/actions/feature_state.py` — split actionable counts; new state
+- `src/canopy/actions/commit.py` (line 165) — `address: str | None = None` param
+- **New:** `src/canopy/actions/bot_resolutions.py` — `record_resolution()`, `load_resolutions()`, `is_resolved()`
+- **New:** `src/canopy/actions/bot_status.py` — `bot_comments_status()` rollup
+- `src/canopy/cli/main.py` — `cmd_bot_status` + subparser; extend `cmd_commit` argparse
+- `src/canopy/mcp/server.py` — register `bot_comments_status` tool
+- `tests/test_bot_resolutions.py` (new), `tests/test_bot_status.py` (new), `tests/test_commit.py` (extended), `tests/test_feature_state.py` (extended)
+
+**Implementation order:**
+
+1. Add `id` to normalized comments. Update fixtures in `tests/test_review_filter.py` and `tests/test_reads.py`.
+2. New `actions/bot_resolutions.py` (file IO for `.canopy/state/bot_resolutions.json`). Unit tests.
+3. Split actionable counts in `_per_repo_facts`. Use `bot_authors()` helper from N3 (or fallback to `author_type == "Bot"` if N3 not yet in).
+4. Add `awaiting_bot_resolution` state in `_decide_state` per trigger rules.
+5. Extend `commit()` with `--address` param. Resolve comment ID. Format message. Record resolution.
+6. Build `bot_comments_status` rollup. CLI + MCP wiring.
+7. `next_actions` updates: when state is `awaiting_bot_resolution`, surface `canopy commit --address <id> -m "..."` per unresolved thread.
+
+**Verification:**
+- Unit: resolution round-trip; rollup correctness with mixed resolved/unresolved.
+- Unit: `_decide_state` returns `awaiting_bot_resolution` for the four trigger conditions.
+- Integration: workspace with fake bot comment → `commit --address <id> -m "fix"` → `bot_resolutions.json` has entry → `bot_comments_status` returns `all_resolved: true`.
+- Manual: real PR with bot comments → `canopy bot-status` shows them → `canopy commit --address` produces a properly attributed commit → re-run shows resolved.
+
+### 2.5 — Historian: cross-session feature memory
+
+(Detailed spec — same treatment as N2/N3.)
+
+**Goal:** capture decisions, events, comment activity, and PR context for each feature into a persistent markdown memory file (`<workspace>/.canopy/memory/<feature>.md`) that future agents read automatically on `canopy switch`. Eliminates the "agent re-derives PR review state, past decisions, file context every session" tax. Especially valuable for cross-session agent handoff (Monday agent works on X; Wednesday a fresh session resumes — historian carries the context cold).
+
+**Why after N2:** historian's "comments resolved" log consumes N2's `bot_resolutions.json` and `commit --address` flow as data sources. Without N2, historian would reimplement structured comment-resolution state.
+
+**Eight capture categories** (decisions use the hybrid mechanism per cross-cutting 1.8):
+
+| # | Category | Examples | Trigger |
+|---|---|---|---|
+| 1 | Decisions | "chose `jwt.decode` over `pyjwt`; reason: stdlib only" | **Hybrid** (per 1.8): primary `mcp__canopy__historian_decide` + Stop-hook tail-parse backup |
+| 2 | Events | "edited `src/auth/oauth.py`", "ran preflight (passed)" | PostToolUse hook on Bash + Edit, in active worktree only; one-line summary |
+| 3 | Pauses | "blocked on design-system copy" | Stop hook (end of session) or explicit `historian_pause` |
+| 4 | Comments read | "read coderabbit comment on `cache.py:42` — suggested rename" | PostToolUse on `review_comments` MCP call; logs each unique comment URL once per session |
+| 5 | Comments resolved | "addressed comment 123456 in `abc123de`: renamed `hit_rate → cache_hit_rate`" | PostToolUse on `commit --address` (consumes N2's flow); pulls comment title + sha + diff snippet |
+| 6 | Classifier-resolved | "temporal classifier marked 3 threads likely-resolved (file modified since)" | PostToolUse on `review_comments`; logs classifier's `likely_resolved` output once per session |
+| 7 | PR context | "opened PR #142, addresses SIN-7, includes commits abc/def/ghi" | PostToolUse on `ship` (Wave 2.4) or explicit `historian_pr_opened` |
+| 8 | PR updates | "pushed 2 commits to PR #142: addressed bot 789, added edge-case test" | PostToolUse on `push` when an open PR exists for the feature |
+
+**File format** (`.canopy/memory/<feature>.md`):
+
+Three top-level sections, newest content first within each:
+
+```markdown
+# Feature: <name> · <linear-id>
+
+## Resolutions log
+- ✓ comment <id> (<author>, <file:line>) resolved by <sha>
+  <gist of resolution>
+- ⊙ comment <id> (<author>, <file:line>) likely-resolved by classifier
+  <classifier rationale>
+- ⚠ comment <id> (<author>, <file:line>) UNRESOLVED
+  <last status>
+- ⊘ comment <id> (<author>, <file:line>) DEFERRED
+  <deferral reason>
+
+## PR context
+### PR #<n> — <title>
+**Opened:** <date> against <base>
+**Branch:** <feature>
+**Rationale:** <why this PR>
+**Commits:** <count>; review rounds: <n>
+
+### Updates
+- <date>: <action>
+
+## Sessions (newest first)
+### <date> — <status>
+**Where we are:** ...
+**Last decision:** ...
+**Open questions:** ...
+**Last command:** ...
+**Touched:** ...
+```
+
+**Switch integration:** `mcp__canopy__switch(feature)` response includes a `memory: <markdown>` field for the new active feature. Agent sees memory immediately on switch — no extra MCP call.
+
+**Compaction:** old sessions get LLM-summarized when (a) `canopy switch <other>` (compact the just-finished session) or (b) explicit `historian_compact`. Resolution log + PR context are NEVER compacted (always-current source of truth). Keeps the file readable as it grows.
+
+**Files to touch:**
+
+- **New:** `src/canopy/actions/historian.py` — `record_decision`, `record_event`, `record_pause`, `record_comment_read`, `record_comment_resolved`, `record_comment_deferred`, `record_pr_context`, `record_pr_update`, `compact`, `read`, `format_for_agent`
+- **New:** `tests/test_historian.py`
+- `src/canopy/mcp/server.py` — register 5 historian tools (`historian_decide`, `historian_pause`, `historian_defer_comment`, `feature_memory`, `historian_compact`)
+- `src/canopy/cli/main.py` — `cmd_historian_show`, `cmd_historian_compact` (read-only inspection + manual compact trigger)
+- `src/canopy/actions/switch.py` — extend response with `memory` field via `format_for_agent(feature)`
+- `src/canopy/actions/commit.py` — when `--address` succeeds, also call `record_comment_resolved` (extends N2's flow)
+- `src/canopy/actions/reads.py` — when `review_comments` returns, call `record_comment_read` and `record_classifier_resolved`
+- `src/canopy/agent_setup/skills/using-canopy/SKILL.md` — teach: read memory on switch; call `historian_decide` at meaningful moments; emit `<historian-decisions>` tail as fallback
+- Stop hook (autopilot integration): scan last assistant message for `<historian-decisions>` block; parse; dedup against tool-call writes; persist
+- PostToolUse hooks (autopilot integration): events for Bash/Edit, comment-read for `review_comments`, comment-resolved for `commit --address`, pr-context for `ship`, pr-update for `push`
+
+**Implementation order:**
+
+1. New `actions/historian.py`: file IO + record functions for each category. Pure module; unit-tested independently.
+2. MCP tool registration. The 5 new tools wrap the record functions.
+3. Skill update: `using-canopy/SKILL.md` gains a "Historian" section teaching when to call each tool, plus the tail-fallback format.
+4. Switch integration: extend `switch_impl` response with `memory: format_for_agent(feature)`.
+5. Hooks integration: PostToolUse + Stop hook bundle (lands as part of autopilot's observer category).
+6. Commit + review integration: extend N2's `commit --address` flow to call `record_comment_resolved`; extend `review_comments` reads to call `record_comment_read` and `record_classifier_resolved`.
+7. Compaction: LLM-summarize old sessions; trigger on switch-away.
+
+**Verification:**
+- Unit: each `record_*` appends correctly; `format_for_agent` renders all 3 sections in order; compaction summarizes without losing resolution log or PR context.
+- Integration: `workspace_with_feature` → simulate session: `review_comments` call → `commit --address` → `historian_decide` → switch away → switch back → assert memory has resolution-log entry + classifier-resolved entry + decision entry + session entry.
+- Hybrid mechanism: agent calls `historian_decide` directly: persisted once. Agent emits format-tail without tool call: Stop-hook persists. Agent does both with same title: deduped to one entry.
+- Manual: real PR with bot comments → use canopy normally for an hour → `canopy historian show <feature>` → eyeball that memory captures decisions, events, resolutions, classifier output, PR context.
+
+**Effort:** ~5–6 days. Depends on autopilot's Stop + PostToolUse hook infrastructure being in place; if those slip, historian's auto-capture (categories 2, 4, 5, 6, 7, 8) defers and only categories 1 (decisions, hybrid) and 3 (pauses, explicit) ship in v1.
+
+---
+
+## Section 3 — Existing pending plans (status + position in sequence)
+
+Each plan stays in its existing file. The summaries below note where they slot relative to the new work.
+
+### 3.1 — Wave 2.4 `ship` ([plan](~/.claude/plans/2026-04-26-canopy-wave-2-4-ship.md))
+
+Ship a feature: commit + push + open/update PR per repo, with cross-repo PR descriptions linking siblings. Depends on Wave 2.3 (✅ shipped). **Slots after N2** (so PRs opened by `ship` correctly trigger the bot-comment-tracking workflow). Medium priority — can be deferred if N1/N2/N3 take longer than expected.
+
+### 3.2 — Wave 4 `draft_replies` ([plan](~/.claude/plans/2026-04-26-canopy-wave-4-draft-replies.md))
+
+Auto-draft reply text for PR comments addressed in subsequent commits. Template-based (no LLM in v1). Depends on the temporal classifier (✅ shipped). **Slots alongside or after N2** — both deal with bot/comment workflows; cross-pollination likely. Useful pairing: `commit --address <id>` resolves a comment; `draft_replies` then drafts the "Done in <sha>" reply.
+
+### 3.3 — `worktree-bootstrap` ([plan](~/.claude/plans/2026-04-28-canopy-worktree-bootstrap.md))
+
+Env-file copy + dep install + `.code-workspace` generation when worktrees are created. Adds `env_files`, `install_cmd`, `ide_settings` per `RepoConfig`. **Independent — can ship anytime after doctor.** No deps on N2/N3/arch-doc. Quality-of-life win for new feature spinups.
+
+### 3.4 — CI status ([plan](~/.claude/plans/2026-04-28-canopy-ci-status.md))
+
+CI status in `feature_state` + `awaiting_ci` state + `pr_checks` MCP tool. **Slots after N2** — both add states to the state machine; would be useful to land them together to avoid two state-machine refactors. Or after `ship` to cleanly answer "is this PR truly ready to merge?"
+
+### 3.5 — Sidebar single-tree ([plan](~/.claude/plans/2026-04-26-canopy-sidebar-single-tree.md))
+
+Extension UI: collapse 5 sidebar trees → 1 unified tree. **Independent of all backend work.** Can ship anytime. Good candidate for a quick win between heavier backend plans.
+
+### 3.6 — Action drawer ([plan](~/.claude/plans/2026-04-26-canopy-action-drawer.md))
+
+Extension UI: rebuild dashboard right rail with ~16 wired actions. **Depends on Wave 2.4 (`ship`) + Wave 4 (`draft_replies`)** for full action surface. Without those, ~6 of the 16 actions stay dark. Lowest-priority extension work.
+
+### 3.7 — Cross-feature conflicts ([plan](~/.claude/plans/2026-04-28-canopy-cross-feature-conflicts.md))
+
+`canopy conflicts` for cross-feature file-overlap detection. **Lowest priority overall.** Nice-to-have; defer until everything above lands.
+
+---
+
+## Section 4 — Recommended execution order
+
+Concrete sequence with rough effort estimates:
+
+1. **Architecture doc** (`docs/architecture/providers.md`) — design only, ~1 day
+2. **Doctor** (existing plan + 6 new categories from §2.2 + version handshake) — ~3-4 days
+3. **N3 augment skill** (§2.3) — ~2-3 days
+4. **N2 bot-comment tracking** (§2.4) — ~3 days
+5. **Historian** (§2.5) — ~5-6 days
+6. **First issue-provider scaffold** — Linear refactored into the contract, GitHub Issues backend per Phil — ~3-4 days
+7. **Worktree bootstrap** ([3.3](~/.claude/plans/2026-04-28-canopy-worktree-bootstrap.md)) — ~2 days
+8. **Sidebar single-tree** ([3.5](~/.claude/plans/2026-04-26-canopy-sidebar-single-tree.md)) — ~1 day
+9. **Wave 2.4 `ship`** ([3.1](~/.claude/plans/2026-04-26-canopy-wave-2-4-ship.md)) — ~2-3 days
+10. **Wave 4 `draft_replies`** ([3.2](~/.claude/plans/2026-04-26-canopy-wave-4-draft-replies.md)) — ~2 days
+11. **CI status** ([3.4](~/.claude/plans/2026-04-28-canopy-ci-status.md)) — ~2 days
+12. **Action drawer** ([3.6](~/.claude/plans/2026-04-26-canopy-action-drawer.md)) — ~3-4 days
+13. **Cross-feature conflicts** ([3.7](~/.claude/plans/2026-04-28-canopy-cross-feature-conflicts.md)) — ~1-2 days
+
+Estimated total: ~30-36 days of focused engineering. The first 6 items (~17-20 days) deliver the dogfood-failure recoveries, the new agent-facing customization surface, cross-session feature memory, and the issue-provider scaffold Phil asked for.
+
+---
+
+## Section 5 — Out of scope / explicit deferrals
+
+| Item | Why deferred |
+|---|---|
+| Wave 2.9 B4 — cross-workspace MCP (`workspace_select` tool, global `~/.claude/mcp.json`, `~/.canopy/workspaces.json` registry) | Bigger design surface; per-workspace `.mcp.json` works fine after doctor lands. Revisit later. |
+| Augment config via `canopy config augments.<key>` CLI | `cmd_config` is flat-only; nested-key support is its own refactor. Augment-canopy skill writes TOML directly in v1. |
+| Augment validation (catch typos like `preflight_cmmd`) | Lenient parser silently ignores. Add `canopy doctor --check-augments` later, or fold into doctor. |
+| LLM-augmented draft replies on bot comments | Wave 4.1 future work; v1 templates are sufficient. |
+| Auto-running `canopy doctor` on extension activation | User-invoked only in v1; opt-in flag possible later. |
+| Per-feature augments (different preflight for different features in same workspace) | Workspace + per-repo is enough for v1. |
+| **Provider-injection for non-issue cases** (bot-author, CI providers, code-review platforms, IDE workspace formats, pre-commit frameworks) | Effort cap: < 5% of arch-doc effort. Adopt the pattern only if it drops in seamlessly. Otherwise current handling stays. |
+
+---
+
+## Section 6 — End-to-end verification (smoke test for the first 6 items)
+
+After arch doc + doctor + N3 + N2 + historian + first issue-provider scaffold land, this scenario should work cold on a new machine:
+
+```bash
+# Fresh machine. Install via pipx.
+pipx install git+https://github.com/ashmitb95/canopy.git
+
+# In a multi-repo workspace:
+cd ~/projects/my-product
+canopy init                                       # creates canopy.toml, hooks, .mcp.json, installs using-canopy skill
+canopy setup-agent --skill augment-canopy        # opt-in second skill (N3)
+
+# Customize per-workspace via the agent (uses augment-canopy skill):
+# user: "this workspace uses ruff for preflight, tracks coderabbit + korbit bots, uses GitHub Issues not Linear"
+# agent edits canopy.toml: [augments] preflight_cmd, review_bots, [issue_provider] name="github_issues" repo="..."
+
+# Use canopy:
+canopy switch SIN-42                              # provider-agnostic alias resolves via configured issue_provider
+                                                  # response includes memory: <markdown> from historian (empty on first switch)
+canopy preflight                                  # honors augments.preflight_cmd (ruff)
+canopy commit -m "..."                            # historian records event + decision (via skill-driven historian_decide)
+canopy push
+
+# Address bot comments on the PR:
+canopy bot-status SIN-42                          # lists unresolved bot comments (N2)
+canopy commit --address 123456 -m "rename foo to bar"   # auto-formats with comment URL
+                                                        # historian records resolution (sha + comment title) automatically
+
+# Switch away and come back days later:
+canopy switch SIN-99                              # historian compacts SIN-42's last session
+# ...work on other feature for 2 days...
+canopy switch SIN-42                              # response.memory contains: resolutions log (resolved + classifier-resolved + deferred), PR context, last paused session
+                                                  # agent reads memory; knows immediately what's resolved, what's open, where it left off
+
+# 6 months later, on a different machine:
+canopy doctor --check                             # detects stale CLI/MCP/skill (doctor + N1 categories)
+canopy doctor --fix                               # converges everything to current
+```
+
+Each step exercises one of the first-6 deliverables. The full chain validates that arch doc → doctor → N3 → N2 → historian → issue-provider scaffold compose without friction.
+
+---
+
+## Section 7 — Critical files (cross-plan index)
+
+Files touched by multiple sub-plans / artifacts. Listed once here so executors of any individual plan know which adjacent plans share the file.
+
+| File | Touched by |
+|---|---|
+| [`src/canopy/__init__.py`](src/canopy/__init__.py) | Doctor (§2.2 — `__version__`) |
+| [`src/canopy/agent_setup/__init__.py`](src/canopy/agent_setup/__init__.py) | Doctor (§2.2 — install_skill iteration), N3 (§2.3 — generalize signatures) |
+| [`src/canopy/agent_setup/skills/using-canopy/SKILL.md`](src/canopy/agent_setup/skills/using-canopy/SKILL.md) | N3 (§2.3 — moved + extended), Historian (§2.5 — teach historian tools + tail format) |
+| [`src/canopy/cli/main.py`](src/canopy/cli/main.py) | Doctor (`cmd_doctor`), N2 (`cmd_bot_status`, `cmd_commit --address`), N3 (`run_precommit` call site), Historian (`cmd_historian_show`, `cmd_historian_compact`) |
+| [`src/canopy/mcp/server.py`](src/canopy/mcp/server.py) | Doctor (`version()`), N2 (`bot_comments_status`), N3 (`run_precommit` call site), arch doc (issue-provider tools), Historian (5 historian tools) |
+| [`src/canopy/workspace/config.py`](src/canopy/workspace/config.py) | N3 (augment fields), arch doc (`[issue_provider]` block) |
+| [`src/canopy/integrations/github.py`](src/canopy/integrations/github.py) (line 537) | N2 (add `id` field) |
+| [`src/canopy/integrations/precommit.py`](src/canopy/integrations/precommit.py) | N3 (signature change) |
+| [`src/canopy/integrations/linear.py`](src/canopy/integrations/linear.py) | Arch doc / first scaffold (refactor into IssueProvider contract) |
+| [`src/canopy/actions/feature_state.py`](src/canopy/actions/feature_state.py) | N2 (state + facts) |
+| [`src/canopy/actions/commit.py`](src/canopy/actions/commit.py) | N2 (`--address` param), Historian (call `record_comment_resolved` on `--address` success) |
+| [`src/canopy/actions/reads.py`](src/canopy/actions/reads.py) | Historian (call `record_comment_read` + `record_classifier_resolved` on `review_comments`) |
+| [`src/canopy/actions/switch.py`](src/canopy/actions/switch.py) | Historian (extend response with `memory: <markdown>` field) |
+| [`src/canopy/features/coordinator.py`](src/canopy/features/coordinator.py) | N3 (`run_precommit` call site) |
+| [`vscode-extension/src/canopyClient.ts`](vscode-extension/src/canopyClient.ts) | Doctor (version handshake on MCP startup) |
+
+## Section 8 — New files this roadmap introduces
+
+- **`docs/architecture/providers.md`** — provider-injection design reference (arch doc, §2.1)
+- `src/canopy/upgrade/` *(deleted from earlier plan — no longer a separate package; logic absorbed into `src/canopy/actions/doctor.py`)*
+- `src/canopy/actions/augments.py` (N3)
+- `src/canopy/agent_setup/skills/using-canopy/SKILL.md` (moved from `agent_setup/skill.md`) (N3 + Historian extensions)
+- `src/canopy/agent_setup/skills/augment-canopy/SKILL.md` (N3 — new content)
+- `src/canopy/actions/bot_resolutions.py`, `bot_status.py` (N2)
+- **`src/canopy/actions/historian.py`** (Historian, §2.5)
+- **`<workspace>/.canopy/memory/<feature>.md`** (Historian, §2.5 — runtime artifact, per-feature; not committed to repos by default — listed in `.canopy/.gitignore`)
+- **`src/canopy/providers/__init__.py`**, `linear.py`, `github_issues.py` (first issue-provider scaffold)
+- `tests/test_doctor.py` extensions (existing file; adds install-staleness + version-handshake fixtures)
+- `tests/test_augments.py`, `tests/test_bot_resolutions.py`, `tests/test_bot_status.py` (new)
+- `tests/test_historian.py` (Historian, §2.5)
+- `tests/test_providers.py` (first issue-provider scaffold)
+
+---
+
+## Section 9 — GitHub Issues tracking
+
+**Goal:** every pending plan becomes a trackable GitHub issue on `ashmitb95/canopy`. Plan files move in-tree under `docs/plans/` so contributors (Phil and others) can comment on the plans themselves; issues handle status, priority, dependencies, and discussion.
+
+### 9.1 — Plan file migration (in-tree)
+
+| Current location | New location | Notes |
+|---|---|---|
+| `~/.claude/plans/2026-04-26-canopy-action-drawer.md` | `docs/plans/action-drawer.md` | rename: drop date prefix |
+| `~/.claude/plans/2026-04-26-canopy-sidebar-single-tree.md` | `docs/plans/sidebar-single-tree.md` | |
+| `~/.claude/plans/2026-04-26-canopy-wave-2-4-ship.md` | `docs/plans/wave-2-4-ship.md` | |
+| `~/.claude/plans/2026-04-26-canopy-wave-4-draft-replies.md` | `docs/plans/wave-4-draft-replies.md` | |
+| `~/.claude/plans/2026-04-28-canopy-ci-status.md` | `docs/plans/ci-status.md` | |
+| `~/.claude/plans/2026-04-28-canopy-cross-feature-conflicts.md` | `docs/plans/cross-feature-conflicts.md` | |
+| `~/.claude/plans/2026-04-28-canopy-doctor.md` | `docs/plans/doctor.md` | append §2.2 contents (install-staleness categories) before publishing |
+| `~/.claude/plans/2026-04-28-canopy-worktree-bootstrap.md` | `docs/plans/worktree-bootstrap.md` | |
+| `~/.claude/plans/2026-04-26-canopy-skipped-phases.md` | (do not migrate) | superseded by this roadmap |
+| `~/.claude/plans/2026-04-26-canopy-wave-2-3-commit-push.md` | `docs/plans/archive/wave-2-3-commit-push.md` | shipped; archive for history |
+| `~/.claude/plans/lets-plaan-all-3-melodic-cloud.md` (this file) | `docs/plans/roadmap.md` | the in-tree canonical roadmap |
+
+The four new artifacts embedded in this roadmap (Sections 2.1–2.5) get extracted into their own `docs/plans/<name>.md` files at execution time (one per artifact):
+
+- `docs/plans/providers-arch.md` (from §2.1)
+- `docs/plans/augments.md` (from §2.3 — N3)
+- `docs/plans/bot-tracking.md` (from §2.4 — N2)
+- `docs/plans/historian.md` (from §2.5)
+
+### 9.2 — Issue template
+
+Add `.github/ISSUE_TEMPLATE/plan.yml`:
+
+```yaml
+name: Plan tracking
+description: Track a planned feature against its in-repo plan file
+title: "[plan] "
+labels: ["plan-tracker"]
+body:
+  - type: input
+    id: plan-file
+    attributes:
+      label: Plan file
+      description: "Path to the in-repo plan file"
+      placeholder: "docs/plans/<name>.md"
+    validations:
+      required: true
+  - type: dropdown
+    id: priority
+    attributes:
+      label: Priority
+      options: [P0 (urgent), P1 (next up), P2 (queued), P3 (nice-to-have)]
+  - type: input
+    id: effort
+    attributes:
+      label: Effort estimate
+      placeholder: "~N days"
+  - type: input
+    id: depends-on
+    attributes:
+      label: Depends on
+      placeholder: "#<issue-number> (if any)"
+  - type: textarea
+    id: summary
+    attributes:
+      label: Summary
+      description: "2-3 sentences: what this delivers and why"
+    validations:
+      required: true
+  - type: textarea
+    id: acceptance
+    attributes:
+      label: Acceptance criteria
+      placeholder: "- [ ] item\n- [ ] item"
+    validations:
+      required: true
+  - type: textarea
+    id: out-of-scope
+    attributes:
+      label: Out of scope
+```
+
+### 9.3 — Labels to create
+
+Via `gh label create` (one-shot script `scripts/setup-labels.sh`):
+
+| Label | Color | Description |
+|---|---|---|
+| `P0` | `#b60205` | urgent |
+| `P1` | `#d93f0b` | next up |
+| `P2` | `#fbca04` | queued |
+| `P3` | `#0e8a16` | nice-to-have |
+| `plan-tracker` | `#5319e7` | tracks an in-repo plan file |
+| `cli` | `#1d76db` | scope: CLI |
+| `mcp` | `#1d76db` | scope: MCP server |
+| `backend` | `#1d76db` | scope: Python backend |
+| `extension` | `#1d76db` | scope: VSCode extension |
+| `docs` | `#0075ca` | scope: documentation |
+| `tests` | `#0075ca` | scope: tests |
+| `blocked` | `#000000` | status: blocked |
+| `in-progress` | `#fbca04` | status: in flight |
+| `ready-for-review` | `#0e8a16` | status: PR open |
+
+### 9.4 — Issues to create (13 sub-issues + 1 parent epic)
+
+| # | Issue title | Plan file | Priority | Scope labels | Depends on |
+|---|---|---|---|---|---|
+| Epic | Canopy roadmap 2026-05 — agent surface + dogfood-failure recoveries | docs/plans/roadmap.md | P0 | plan-tracker | n/a |
+| 1 | Architecture: provider injection contract (issue providers) | docs/plans/providers-arch.md | P0 | plan-tracker, docs | (epic) |
+| 2 | canopy doctor — state-file integrity + install-staleness recovery | docs/plans/doctor.md | P0 | plan-tracker, cli, mcp, backend | (epic) |
+| 3 | Augment skill — per-workspace customization (preflight_cmd, review_bots, test_cmd) | docs/plans/augments.md | P1 | plan-tracker, mcp, cli, backend | #2 |
+| 4 | Bot-comment tracking — `commit --address`, awaiting_bot_resolution state | docs/plans/bot-tracking.md | P1 | plan-tracker, mcp, cli, backend | #3 |
+| 5 | Historian — cross-session feature memory | docs/plans/historian.md | P1 | plan-tracker, mcp, backend | #4 |
+| 6 | Issue-provider scaffold — Linear refactor + GitHub Issues backend | docs/plans/issue-providers.md | P1 | plan-tracker, mcp, backend | #1 |
+| 7 | Worktree bootstrap — env-file copy, dep install, IDE workspace gen | docs/plans/worktree-bootstrap.md | P2 | plan-tracker, mcp, cli, backend | #2 |
+| 8 | Extension sidebar — collapse 5 trees → 1 unified tree | docs/plans/sidebar-single-tree.md | P2 | plan-tracker, extension | n/a |
+| 9 | Wave 2.4 — `canopy ship` (commit + push + open PR) | docs/plans/wave-2-4-ship.md | P2 | plan-tracker, mcp, cli, backend | #4 |
+| 10 | Wave 4 — `draft_replies` (auto-draft addressed-thread replies) | docs/plans/wave-4-draft-replies.md | P2 | plan-tracker, mcp, backend | #4 |
+| 11 | CI status integration — `awaiting_ci` state + `pr_checks` MCP tool | docs/plans/ci-status.md | P2 | plan-tracker, mcp, backend | #4 |
+| 12 | Extension action drawer — dashboard right-rail rebuild (~16 actions) | docs/plans/action-drawer.md | P3 | plan-tracker, extension | #9, #10 |
+| 13 | `canopy conflicts` — cross-feature file-overlap detection | docs/plans/cross-feature-conflicts.md | P3 | plan-tracker, mcp, cli, backend | n/a |
+
+### 9.5 — Per-issue body generation
+
+Each issue body is a 5-section condensation derived from the plan file:
+
+1. **Plan file link** (1 line, top of body): `**Plan:** [docs/plans/<name>.md](docs/plans/<name>.md)`
+2. **Metadata** (4 lines): Status / Priority / Effort / Depends on (from the table in 9.4)
+3. **Summary** (2–3 sentences, from the plan's "Goal" section)
+4. **Acceptance criteria** (5–8 checkbox items derived from the plan's "Verification" section, rephrased as user-visible outcomes)
+5. **Out of scope** (3–5 bullets from the plan's "Out of scope" / "Non-goals" section)
+
+The plan file remains the deeper execution reference; the issue body is the executive summary + tracking checklist.
+
+### 9.6 — Implementation steps (when execution begins)
+
+1. Create `docs/plans/` directory and `docs/plans/archive/` subdirectory in the canopy repo.
+2. Move/rename the 8 active plans + 1 archived plan per the table in 9.1. Update the in-tree doctor plan with §2.2 contents (install-staleness categories + version handshake additions).
+3. Extract the four embedded artifacts (Sections 2.1–2.5) into their own `docs/plans/<name>.md` files.
+4. Move this roadmap to `docs/plans/roadmap.md`.
+5. Commit the plan migration in one atomic commit on a `chore/plan-migration` branch; PR to main.
+6. Add `.github/ISSUE_TEMPLATE/plan.yml` and `scripts/setup-labels.sh`. Run the label-setup script.
+7. Create the parent epic issue first; capture its issue number.
+8. Create each of the 13 sub-issues. Reference the epic in each via "Part of #<epic-number>". Use the priority + scope labels per the table.
+9. Edit the parent epic body to include a checklist of all 13 sub-issues.
+10. Going forward: when work starts on a plan, label its issue `in-progress`; when its PR opens, label `ready-for-review`; when merged, close the issue.
+
+### 9.7 — Workflow conventions after migration
+
+- **Discussion happens on the issue**, not the plan file. The plan file is the spec; the issue is the tracker.
+- **Plan amendments happen on the plan file** via PR. The PR description references the issue.
+- **Cross-issue dependencies are surfaced via the `Depends on:` line in the body**, not via labels. Status-board logic can still parse it.
+- **Sub-issues link to the epic** via "Part of #<epic-number>" in the body. Epic body has the checklist.
+- **Closing the epic** requires all sub-issues closed.
+
+---
+
+## What changes in `~/.claude/plans/` after this is approved
+
+- This file (`lets-plaan-all-3-melodic-cloud.md`) becomes the canonical execution roadmap and migrates to `docs/plans/roadmap.md` per §9.1.
+- The existing `2026-04-26-canopy-skipped-phases.md` is **superseded** — its tracker function moves here. Keep the file as historical reference; don't migrate.
+- The existing `2026-04-28-canopy-doctor.md` plan is **extended** with §2.2 contents (six new categories + version handshake) before being moved to `docs/plans/doctor.md`.
+- `2026-04-26-canopy-wave-2-3-commit-push.md` is shipped — archive at `docs/plans/archive/`.
+- All other existing plan files migrate to `docs/plans/` per §9.1.
+- After migration, `~/.claude/plans/` no longer hosts the canonical plan; the in-repo `docs/plans/` is canonical. Local copies can be kept as scratch but should not be edited (drift risk).

--- a/docs/plans/sidebar-single-tree.md
+++ b/docs/plans/sidebar-single-tree.md
@@ -1,0 +1,767 @@
+# Canopy Sidebar — Collapse to Single Tree (Option A)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the 5 separate Canopy tree views (Linear Issues, Features, Worktrees, Changes, Review Readiness) with a single unified "Canopy" tree containing three sections: ACTIVE (expandable to per-repo rows), FEATURES (with status pills), and LINEAR INBOX (collapsed mini-section).
+
+**Architecture:** One `CanopyTreeProvider` returning polymorphic `CanopyNode` types tagged by `kind` (`section` | `active` | `active-repo` | `feature` | `feature-repo` | `linear-issue`). Each top-level section is a TreeItem; expansion produces typed children. The provider replaces all 5 existing providers; their files are deleted. Action commands (`canopy.openDashboard`, `canopy.switchFeature`, etc.) re-bind to context values on the new view ID.
+
+**Tech Stack:** TypeScript, VS Code Extension API (`TreeDataProvider`, `TreeItem`, `EventEmitter`), `esbuild` bundle, packaged as `.vsix` via `@vscode/vsce`.
+
+**Working directory:** `/Users/ashmit/projects/canopy/vscode-extension/`
+
+**Why this is needed:** The user reported the existing 5-tree sidebar feels "redundant" and "gives me very little as actionable" because the dashboard + cockpit panels already cover the detail. The sidebar's unique job is (1) always-visible state, (2) launcher / index, (3) glanceable status — none of which need 5 trees.
+
+---
+
+## Pre-flight: Establish baseline
+
+- [ ] **Step 0.1: Read the survey report** below before touching any code.
+
+```
+Five existing providers (vscode-extension/src/views/):
+- featuresProvider.ts (229L) — FeaturesProvider(client, getActiveFeature)
+  Returns FeatureNode → RepoUnderFeatureNode children
+  contextValue: "feature" / "feature.repo"
+  Exposes: client.featureList, workspace_status, .canopy/worktrees scan
+
+- linearIssuesProvider.ts (118L) — LinearIssuesProvider(client)
+  Returns StateGroupNode → IssueNode children
+  contextValue: "linear.group" / "linear.issue"
+  Exposes: client.linearMyIssues(50), groups by state ("Todo", "In Progress")
+
+- worktreesProvider.ts (105L) — WorktreesProvider(client)
+  Returns WorktreeFeatureNode → WorktreeRepoNode children
+  contextValue: "worktree.feature" / "worktree.repo" (no menus wired)
+  Exposes: client.worktreeInfo, client.workspaceConfig
+  Caches: budgetLabel (used by featuresView.description)
+
+- changesProvider.ts (174L) — ChangesProvider(client, getActiveFeature)
+  Returns ChangesRepoNode → ChangeFileNode children
+  contextValue: "changes.repo" / "changes.file" (no menus wired)
+  Only renders when an active feature exists
+
+- reviewProvider.ts (136L) — ReviewProvider(client)
+  Returns ReviewNode (leaf, no expansion)
+  contextValue: "review.row" (no menus wired)
+  Async per-row fetch via reviewStatus + reviewComments + featureMergeReadiness
+
+extension.ts:160-260 wires all 5 in order, single refresh() fan-out.
+
+package.json contributes.views.canopy:
+- canopy.linearIssues  (when canopy.state == 'ok')
+- canopy.features      (always visible)
+- canopy.worktrees     (when canopy.state == 'ok')
+- canopy.changes       (when canopy.state == 'ok')
+- canopy.review        (when canopy.state == 'ok')
+
+viewsWelcome owners:
+- canopy.features:    no-workspace / no-mcp / loading
+- canopy.linearIssues: not-configured / empty
+
+Title-bar menus on canopy.features:
+- canopy.openCockpit (nav@0)
+- canopy.openNewFeature (nav@1)
+- canopy.refresh (nav@2 — applied to ALL 5 views currently)
+- canopy.reinit (9_danger@1)
+- canopy.reinitDryRun (9_danger@2)
+
+view/item/context menus:
+- viewItem == "feature":      openDashboard, switchFeature, openInIde, featureDone
+- viewItem == "linear.issue": createFeatureFromIssue
+```
+
+- [ ] **Step 0.2: Confirm baseline builds**
+
+```bash
+cd /Users/ashmit/projects/canopy/vscode-extension
+npx tsc --noEmit
+npm run build
+```
+Expected: both clean, dist/extension.js ≈ 442 KB.
+
+---
+
+## Task 1: Add the new unified view to package.json
+
+**Files:**
+- Modify: `vscode-extension/package.json` — `contributes.views.canopy` section
+
+- [ ] **Step 1.1: Replace the 5 view entries with one**
+
+Find the `"views": { "canopy": [...]` block (~lines 41-80). Replace the 5 entries with this single entry:
+
+```json
+"views": {
+  "canopy": [
+    {
+      "id": "canopy.tree",
+      "name": "Canopy",
+      "icon": "media/canopy-icon.svg",
+      "contextualTitle": "Canopy"
+    }
+  ]
+},
+```
+
+Note: no `when` clause — the unified view is always visible. State (no-workspace / no-mcp / loading / ok) is communicated via `viewsWelcome`.
+
+- [ ] **Step 1.2: Update viewsWelcome `view` references**
+
+Find `"viewsWelcome": [...]`. Every entry currently targets `canopy.features` or `canopy.linearIssues`. Change all 5 entries to target `canopy.tree`. Also drop the linearIssues-specific entries (`linearState == 'not-configured'` and `linearState == 'empty'`) — Linear status will be rendered inside the tree itself, not as a viewsWelcome takeover.
+
+The final `viewsWelcome` array should contain exactly 3 entries, all targeting `view: "canopy.tree"`:
+
+```json
+"viewsWelcome": [
+  {
+    "view": "canopy.tree",
+    "when": "canopy.state == 'no-workspace'",
+    "contents": "No Canopy workspace detected.\n\nA workspace is a directory containing a `canopy.toml` file.\n\n[Initialize Canopy here](command:canopy.init)\n\nLearn more about [Canopy](https://github.com/ashmitb95/canopy)."
+  },
+  {
+    "view": "canopy.tree",
+    "when": "canopy.state == 'no-mcp'",
+    "contents": "Canopy detected a workspace, but can't start `canopy-mcp`.\n\n[Install Canopy for me](command:canopy.installBackend)\n\nOr wire up an existing install:\n\n[Set canopy-mcp Path](command:workbench.action.openSettings?%22canopy.canopyMcpPath%22)\n\n[Retry](command:canopy.retryConnect)\n\n[Show Log](command:canopy.showLog)"
+  },
+  {
+    "view": "canopy.tree",
+    "when": "canopy.state == 'loading'",
+    "contents": "Starting canopy-mcp…"
+  }
+]
+```
+
+- [ ] **Step 1.3: Update title-bar menus to single view ID**
+
+Find `"menus": { "view/title": [...]`. Replace every `"view == canopy.features"` with `"view == canopy.tree"`. Drop the multi-view OR clause on `canopy.refresh`. Keep only these 4 commands on the title bar (drop `canopy.reinitDryRun` from title bar — keep it command-palette-only since it's rarely needed):
+
+```json
+"view/title": [
+  {
+    "command": "canopy.openCockpit",
+    "when": "view == canopy.tree",
+    "group": "navigation@0"
+  },
+  {
+    "command": "canopy.openNewFeature",
+    "when": "view == canopy.tree",
+    "group": "navigation@1"
+  },
+  {
+    "command": "canopy.refresh",
+    "when": "view == canopy.tree",
+    "group": "navigation@2"
+  },
+  {
+    "command": "canopy.reinit",
+    "when": "view == canopy.tree",
+    "group": "9_danger@1"
+  }
+]
+```
+
+- [ ] **Step 1.4: Update view/item/context menus**
+
+Find `"view/item/context": [...]`. Replace `"view == canopy.features"` with `"view == canopy.tree"` everywhere. Replace `"view == canopy.linearIssues"` with `"view == canopy.tree"` for the createFeatureFromIssue entry. The contextValue checks (`viewItem == feature`, `viewItem == linear.issue`, etc.) stay the same.
+
+Final block:
+
+```json
+"view/item/context": [
+  {
+    "command": "canopy.openDashboard",
+    "when": "view == canopy.tree && viewItem == feature",
+    "group": "1_open@1"
+  },
+  {
+    "command": "canopy.switchFeature",
+    "when": "view == canopy.tree && viewItem == feature",
+    "group": "1_open@2"
+  },
+  {
+    "command": "canopy.openInIde",
+    "when": "view == canopy.tree && viewItem == feature",
+    "group": "1_open@3"
+  },
+  {
+    "command": "canopy.featureDone",
+    "when": "view == canopy.tree && viewItem == feature",
+    "group": "9_destructive@1"
+  },
+  {
+    "command": "canopy.createFeatureFromIssue",
+    "when": "view == canopy.tree && viewItem == linear.issue",
+    "group": "1_open@1"
+  }
+]
+```
+
+- [ ] **Step 1.5: Verify package.json parses**
+
+```bash
+node -e "JSON.parse(require('fs').readFileSync('package.json','utf8')); console.log('ok')"
+```
+Expected output: `ok`
+
+- [ ] **Step 1.6: Commit**
+
+```bash
+git add package.json
+git commit -m "feat(extension): collapse 5 sidebar views to single 'canopy.tree' view"
+```
+
+---
+
+## Task 2: Create the unified tree provider
+
+**Files:**
+- Create: `vscode-extension/src/views/canopyTreeProvider.ts`
+
+- [ ] **Step 2.1: Write the new provider**
+
+Create `vscode-extension/src/views/canopyTreeProvider.ts` with the full content below. The provider returns a single polymorphic `CanopyNode` discriminated by `kind`. Three top-level sections; each section is a TreeItem you can expand.
+
+```typescript
+import * as vscode from "vscode";
+
+import { CanopyClient } from "../canopyClient";
+import { LinearIssue } from "../types";
+
+type Kind =
+  | "section-active"
+  | "section-features"
+  | "section-linear"
+  | "active-feature"     // the row under ACTIVE (clickable → openDashboard)
+  | "active-repo"        // per-repo row under the active feature
+  | "feature"            // a row under FEATURES
+  | "linear-issue"       // a row under LINEAR INBOX
+  | "empty";             // placeholder when a section has no children
+
+export interface CanopyNode {
+  kind: Kind;
+  label: string;
+  description?: string;
+  tooltip?: string;
+  contextValue?: string;
+  iconId?: string;
+  iconColor?: vscode.ThemeColor;
+  command?: vscode.Command;
+  collapsibleState?: vscode.TreeItemCollapsibleState;
+
+  // Payload pointers — used by getChildren when expanding a parent.
+  featureName?: string;
+  repoName?: string;
+  worktreePath?: string;
+  linearIssue?: LinearIssue;
+}
+
+export class CanopyTreeProvider implements vscode.TreeDataProvider<CanopyNode> {
+  private readonly _onDidChange = new vscode.EventEmitter<CanopyNode | undefined>();
+  readonly onDidChangeTreeData = this._onDidChange.event;
+
+  // Caches populated lazily by getChildren so getTreeItem can reference
+  // counts in section labels without re-fetching.
+  private linearCount = 0;
+  private featureCount = 0;
+
+  constructor(
+    private readonly client: CanopyClient,
+    private readonly getActiveFeature: () => string | null,
+  ) {}
+
+  refresh(): void {
+    this._onDidChange.fire(undefined);
+  }
+
+  getTreeItem(node: CanopyNode): vscode.TreeItem {
+    const item = new vscode.TreeItem(node.label, node.collapsibleState);
+    if (node.description !== undefined) item.description = node.description;
+    if (node.tooltip !== undefined) item.tooltip = node.tooltip;
+    if (node.contextValue !== undefined) item.contextValue = node.contextValue;
+    if (node.command !== undefined) item.command = node.command;
+    if (node.iconId !== undefined) {
+      item.iconPath = node.iconColor
+        ? new vscode.ThemeIcon(node.iconId, node.iconColor)
+        : new vscode.ThemeIcon(node.iconId);
+    }
+    return item;
+  }
+
+  async getChildren(parent?: CanopyNode): Promise<CanopyNode[]> {
+    if (!parent) {
+      // Root: three sections.
+      return [
+        {
+          kind: "section-active",
+          label: "ACTIVE",
+          collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
+          contextValue: "section",
+        },
+        {
+          kind: "section-features",
+          label: "FEATURES",
+          description: this.featureCount ? `${this.featureCount}` : undefined,
+          collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
+          contextValue: "section",
+        },
+        {
+          kind: "section-linear",
+          label: "LINEAR INBOX",
+          description: this.linearCount ? `${this.linearCount} todos` : undefined,
+          collapsibleState: vscode.TreeItemCollapsibleState.Collapsed,
+          contextValue: "section",
+        },
+      ];
+    }
+
+    switch (parent.kind) {
+      case "section-active":
+        return this.activeChildren();
+      case "section-features":
+        return this.featureChildren();
+      case "section-linear":
+        return this.linearChildren();
+      case "active-feature":
+        return this.activeRepoChildren(parent.featureName!);
+      default:
+        return [];
+    }
+  }
+
+  private async activeChildren(): Promise<CanopyNode[]> {
+    const active = this.getActiveFeature();
+    if (!active) {
+      return [
+        {
+          kind: "empty",
+          label: "(no active feature)",
+          tooltip: "Use Canopy: Switch to Feature to set one",
+          collapsibleState: vscode.TreeItemCollapsibleState.None,
+        },
+      ];
+    }
+    let lane;
+    try {
+      lane = await this.client.featureStatus(active);
+    } catch (err) {
+      return [
+        {
+          kind: "empty",
+          label: `error: ${(err as Error).message}`,
+          collapsibleState: vscode.TreeItemCollapsibleState.None,
+        },
+      ];
+    }
+    const repoCount = lane.repos.length;
+    const dirty = Object.values(lane.repo_states).reduce(
+      (n, s) => n + (s.changed_file_count ?? 0),
+      0,
+    );
+    const ahead = Object.values(lane.repo_states).reduce(
+      (n, s) => n + (s.ahead ?? 0),
+      0,
+    );
+    const desc =
+      lane.linear_issue
+        ? `${lane.linear_issue} · ↑${ahead} · ${dirty} dirty`
+        : `↑${ahead} · ${dirty} dirty`;
+    return [
+      {
+        kind: "active-feature",
+        label: active,
+        description: desc,
+        tooltip: lane.linear_title ?? undefined,
+        contextValue: "feature",
+        iconId: "circle-filled",
+        iconColor: new vscode.ThemeColor("charts.green"),
+        collapsibleState: vscode.TreeItemCollapsibleState.Expanded,
+        featureName: active,
+        command: {
+          command: "canopy.openDashboard",
+          title: "Open dashboard",
+          arguments: [active],
+        },
+      },
+    ];
+  }
+
+  private async activeRepoChildren(feature: string): Promise<CanopyNode[]> {
+    let lane;
+    try {
+      lane = await this.client.featureStatus(feature);
+    } catch {
+      return [];
+    }
+    return Object.entries(lane.repo_states).map(([repo, state]) => {
+      const ahead = state.ahead ?? 0;
+      const dirty = state.changed_file_count ?? 0;
+      const parts: string[] = [];
+      if (ahead) parts.push(`↑${ahead}`);
+      if (dirty) parts.push(`${dirty} dirty`);
+      const desc = parts.join(" · ") || "clean";
+      return {
+        kind: "active-repo",
+        label: repo,
+        description: desc,
+        contextValue: "feature.repo",
+        iconId: "repo",
+        collapsibleState: vscode.TreeItemCollapsibleState.None,
+        featureName: feature,
+        repoName: repo,
+        worktreePath: state.worktree_path ?? undefined,
+        command: state.worktree_path
+          ? {
+              command: "vscode.openFolder",
+              title: "Open worktree",
+              arguments: [vscode.Uri.file(state.worktree_path), { forceNewWindow: false }],
+            }
+          : undefined,
+      };
+    });
+  }
+
+  private async featureChildren(): Promise<CanopyNode[]> {
+    let features;
+    try {
+      features = await this.client.featureList();
+    } catch (err) {
+      return [
+        {
+          kind: "empty",
+          label: `error: ${(err as Error).message}`,
+          collapsibleState: vscode.TreeItemCollapsibleState.None,
+        },
+      ];
+    }
+    const active = this.getActiveFeature();
+    const visible = features.filter((f: { name: string }) => f.name !== active);
+    this.featureCount = visible.length;
+    if (!visible.length) {
+      return [
+        {
+          kind: "empty",
+          label: active ? "(no other features)" : "(no features yet)",
+          collapsibleState: vscode.TreeItemCollapsibleState.None,
+        },
+      ];
+    }
+    return visible.map((f: { name: string; repos: string[]; linear_issue?: string | null }) => {
+      const linear = f.linear_issue ? ` · ${f.linear_issue}` : "";
+      return {
+        kind: "feature",
+        label: f.name,
+        description: `${f.repos.length} repo${f.repos.length === 1 ? "" : "s"}${linear}`,
+        contextValue: "feature",
+        iconId: "circle-outline",
+        collapsibleState: vscode.TreeItemCollapsibleState.None,
+        featureName: f.name,
+        command: {
+          command: "canopy.openDashboard",
+          title: "Open dashboard",
+          arguments: [f.name],
+        },
+      };
+    });
+  }
+
+  private async linearChildren(): Promise<CanopyNode[]> {
+    let issues: LinearIssue[];
+    try {
+      issues = await this.client.linearMyIssues(25);
+    } catch (err) {
+      return [
+        {
+          kind: "empty",
+          label: `Linear unavailable: ${(err as Error).message}`,
+          collapsibleState: vscode.TreeItemCollapsibleState.None,
+        },
+      ];
+    }
+    const todos = issues.filter((i) => i.state.toLowerCase() === "todo");
+    this.linearCount = todos.length;
+    if (!todos.length) {
+      return [
+        {
+          kind: "empty",
+          label: "(inbox empty)",
+          collapsibleState: vscode.TreeItemCollapsibleState.None,
+        },
+      ];
+    }
+    return todos.map((i) => ({
+      kind: "linear-issue" as const,
+      label: i.identifier,
+      description: i.title,
+      tooltip: `${i.identifier} · ${i.state}\n${i.title}`,
+      contextValue: "linear.issue",
+      iconId: "issues",
+      collapsibleState: vscode.TreeItemCollapsibleState.None,
+      linearIssue: i,
+      command: {
+        command: "canopy.createFeatureFromIssue",
+        title: "Start feature from this issue",
+        arguments: [i],
+      },
+    }));
+  }
+}
+```
+
+- [ ] **Step 2.2: Type-check the new file in isolation**
+
+```bash
+cd /Users/ashmit/projects/canopy/vscode-extension
+npx tsc --noEmit
+```
+Expected: zero errors.
+
+- [ ] **Step 2.3: Commit**
+
+```bash
+git add src/views/canopyTreeProvider.ts
+git commit -m "feat(extension): add unified CanopyTreeProvider (sections: active / features / linear-inbox)"
+```
+
+---
+
+## Task 3: Wire the new provider in extension.ts
+
+**Files:**
+- Modify: `vscode-extension/src/extension.ts`
+
+- [ ] **Step 3.1: Update imports**
+
+In extension.ts top imports (~lines 13-17), replace the five provider imports with the new one:
+
+```typescript
+// REPLACE these 5 imports:
+//   import { ChangesProvider } from "./views/changesProvider";
+//   import { FeaturesProvider } from "./views/featuresProvider";
+//   import { LinearIssuesProvider } from "./views/linearIssuesProvider";
+//   import { ReviewProvider } from "./views/reviewProvider";
+//   import { WorktreesProvider } from "./views/worktreesProvider";
+// WITH this:
+import { CanopyTreeProvider } from "./views/canopyTreeProvider";
+```
+
+- [ ] **Step 3.2: Slim the `Active` interface**
+
+Find the `interface Active { ... }` block near the top (~lines 28-39). Replace its `features`/`worktrees`/`changes`/`review`/`linearIssues`/`worktreesView` fields with a single `tree` field:
+
+```typescript
+interface Active {
+  client: CanopyClient;
+  tree: CanopyTreeProvider;
+  status: StatusBarManager;
+  refresh: () => Promise<void>;
+  dispose: () => void;
+}
+```
+
+- [ ] **Step 3.3: Replace stub view registrations**
+
+Find the block creating `EmptyTreeProvider` stubs (~lines 99-117). Replace those 5 stubs with a single stub for `canopy.tree`:
+
+```typescript
+const stubProvider = new EmptyTreeProvider();
+const stubTree = vscode.window.createTreeView("canopy.tree", {
+  treeDataProvider: stubProvider,
+});
+const stubSubs: vscode.Disposable[] = [stubTree];
+```
+
+- [ ] **Step 3.4: Replace the real provider wiring**
+
+Find the block creating the 5 real providers (~lines 161-195). Replace it with:
+
+```typescript
+const status = new StatusBarManager(client);
+context.subscriptions.push(status);
+
+const tree = new CanopyTreeProvider(client, () => status.activeFeature);
+const treeView = vscode.window.createTreeView("canopy.tree", {
+  treeDataProvider: tree,
+  showCollapseAll: true,
+});
+context.subscriptions.push(treeView);
+```
+
+- [ ] **Step 3.5: Simplify the refresh fan-out**
+
+Find the `const refresh = async () => { ... }` block (~lines 197-214). Replace with:
+
+```typescript
+const refresh = async () => {
+  try {
+    await status.refresh();
+  } catch (err) {
+    const stack = err instanceof Error ? err.stack ?? err.message : String(err);
+    output.appendLine(`[canopy] status.refresh threw:\n${stack}`);
+  }
+  tree.refresh();
+  void updateLinearState(client, root);
+  treeView.description = status.activeFeature
+    ? `active: ${status.activeFeature}`
+    : "";
+};
+```
+
+- [ ] **Step 3.6: Update the `Active` instance shape**
+
+Find the block assigning `active = { ... }` (~lines 241-254). Replace with:
+
+```typescript
+active = {
+  client,
+  tree,
+  status,
+  refresh,
+  dispose: () => {
+    void client.dispose();
+  },
+};
+```
+
+- [ ] **Step 3.7: Update watcher callbacks**
+
+Find `createWatchers(root, { ... })` (~line 216). The callbacks currently call `changes.refresh()`, `features.refresh()`, etc. Simplify each callback to just `tree.refresh()`:
+
+```typescript
+const watchers = createWatchers(root, {
+  onFeaturesChanged: () => {
+    tree.refresh();
+    CockpitPanel.refreshIfOpen();
+    DashboardPanel.invalidateAll();
+  },
+  onWorktreeChanged: () => {
+    tree.refresh();
+    void status.refresh();
+    CockpitPanel.refreshIfOpen();
+    DashboardPanel.invalidateAll();
+  },
+  onStateFilesChanged: () => {
+    CockpitPanel.refreshIfOpen();
+    DashboardPanel.invalidateAll();
+  },
+});
+```
+
+- [ ] **Step 3.8: Type-check**
+
+```bash
+npx tsc --noEmit
+```
+Expected: zero errors. If you see errors about unused imports for the deleted providers, the imports were missed in Step 3.1 — go back and remove them.
+
+- [ ] **Step 3.9: Commit**
+
+```bash
+git add src/extension.ts
+git commit -m "feat(extension): wire CanopyTreeProvider; remove 5 separate tree views"
+```
+
+---
+
+## Task 4: Delete the old provider files
+
+**Files:**
+- Delete: `vscode-extension/src/views/changesProvider.ts`
+- Delete: `vscode-extension/src/views/featuresProvider.ts`
+- Delete: `vscode-extension/src/views/linearIssuesProvider.ts`
+- Delete: `vscode-extension/src/views/reviewProvider.ts`
+- Delete: `vscode-extension/src/views/worktreesProvider.ts`
+
+- [ ] **Step 4.1: Delete and confirm no references remain**
+
+```bash
+cd /Users/ashmit/projects/canopy/vscode-extension
+rm src/views/changesProvider.ts src/views/featuresProvider.ts src/views/linearIssuesProvider.ts src/views/reviewProvider.ts src/views/worktreesProvider.ts
+grep -rn "ChangesProvider\|FeaturesProvider\|LinearIssuesProvider\|ReviewProvider\|WorktreesProvider" src/
+```
+Expected: only matches in `canopyTreeProvider.ts` (none — that file uses `CanopyTreeProvider`). If any matches in `src/` outside of new provider, fix them.
+
+- [ ] **Step 4.2: Type-check**
+
+```bash
+npx tsc --noEmit
+```
+Expected: zero errors.
+
+- [ ] **Step 4.3: Commit**
+
+```bash
+git add -A src/views/
+git commit -m "chore(extension): delete superseded per-domain tree providers"
+```
+
+---
+
+## Task 5: Bump version, build, package, install
+
+- [ ] **Step 5.1: Bump version**
+
+Edit `package.json`: change `"version": "0.3.3"` to `"version": "0.4.0"` (minor bump — sidebar restructure is user-visible breaking UX change).
+
+- [ ] **Step 5.2: Build + package**
+
+```bash
+cd /Users/ashmit/projects/canopy/vscode-extension
+npm run build
+npm run package
+```
+Expected: dist/extension.js around 440 KB (slightly smaller from removing 5 providers); `canopy-0.4.0.vsix` created.
+
+- [ ] **Step 5.3: Install**
+
+```bash
+code --install-extension canopy-0.4.0.vsix --force
+```
+Expected: "Extension 'canopy-0.4.0.vsix' was successfully installed."
+
+- [ ] **Step 5.4: Reload VS Code window and smoke test**
+
+In VS Code: `Cmd+Shift+P` → `Developer: Reload Window`. Then open `~/projects/canopy-test/` (the integration workspace).
+
+Verify each of these manually:
+- [ ] Single "Canopy" tree appears in the activity bar (no 5 separate sections).
+- [ ] Three top-level rows: ACTIVE, FEATURES, LINEAR INBOX.
+- [ ] LINEAR INBOX is collapsed by default; expanding shows todo issues.
+- [ ] ACTIVE shows the canonical feature with description like `SIN-6 · ↑1 · 1 dirty`; expanding shows per-repo rows.
+- [ ] Clicking the active feature opens the dashboard.
+- [ ] Clicking a per-repo row under ACTIVE opens that worktree folder (only if `worktree_path` exists).
+- [ ] FEATURES lists all non-active features with `N repos` description.
+- [ ] Right-click on a feature row shows: Open Dashboard, Switch to Feature, Open Worktrees in New Window, Mark Feature Done.
+- [ ] Right-click on a Linear issue shows: Start Feature from Linear Issue.
+- [ ] Title-bar buttons: Cockpit, New Feature, Refresh, (overflow) Reinit.
+- [ ] No stale "Worktrees" / "Changes" / "Review Readiness" / "Linear Issues" trees visible.
+
+- [ ] **Step 5.5: Commit**
+
+```bash
+git add package.json canopy-0.4.0.vsix
+git commit -m "chore(extension): release 0.4.0 — single-tree sidebar"
+```
+
+---
+
+## Self-review checklist (run before declaring complete)
+
+- [ ] Search the diff: any reference to `FeaturesProvider`, `WorktreesProvider`, `LinearIssuesProvider`, `ChangesProvider`, `ReviewProvider`, `canopy.features`, `canopy.worktrees`, `canopy.changes`, `canopy.review`, `canopy.linearIssues` outside the changelog/readme? If yes, remove.
+- [ ] viewsWelcome no longer references removed view IDs.
+- [ ] All 4 right-click feature commands still appear in the menu (Open Dashboard, Switch to Feature, Open Worktrees in New Window, Mark Feature Done) after the wiring change.
+- [ ] Title-bar action buttons (Cockpit, New Feature, Refresh) all visible on the new view.
+- [ ] Smoke test was actually performed in VS Code (not skipped).
+
+---
+
+## Rollback plan
+
+If the smoke test reveals issues that block adoption:
+
+```bash
+cd /Users/ashmit/projects/canopy/vscode-extension
+git revert HEAD~5..HEAD  # all 5 commits from this plan
+npm run build && npm run package
+code --install-extension canopy-0.3.3.vsix --force  # reinstall last known good
+```

--- a/docs/plans/sidebar-single-tree.md
+++ b/docs/plans/sidebar-single-tree.md
@@ -1,3 +1,10 @@
+---
+status: queued
+priority: P2
+effort: ~1d
+depends_on: []
+---
+
 # Canopy Sidebar — Collapse to Single Tree (Option A)
 
 > **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.

--- a/docs/plans/wave-2-4-ship.md
+++ b/docs/plans/wave-2-4-ship.md
@@ -1,0 +1,180 @@
+# Wave 2.4 — `ship` as the canonical-feature delivery primitive
+
+## Mental model
+
+`ship` is the capstone of the per-feature workflow: take the canonical feature from "code is committed" to "PR is open + everything's pushed + reviewers can look." It's the multi-repo equivalent of:
+
+```bash
+git push -u origin HEAD && gh pr create --fill --base main
+```
+
+…repeated per repo, with cross-repo PR descriptions that link to each other so a reviewer landing on the backend PR knows about the frontend PR (and vice versa).
+
+After Wave 2.9 + Wave 2.3, the user has:
+
+- `canopy switch X` — focus a feature
+- `canopy commit -m "msg"` — commit across all repos in the feature
+- `canopy push` — push commits
+
+`ship` is the next step: `canopy ship` opens (or updates) one PR per repo in the canonical feature, with linked descriptions and the Linear issue ID in the title. After ship, the workflow is reactive — wait for review, address comments, then `canopy ship` again to push the fixes.
+
+**Idempotent.** First `ship` opens PRs. Second `ship` (after more commits + push) does nothing PR-wise — the PRs auto-update because they track the branch. Third `ship` (after closing one PR manually) reopens the missing one.
+
+**No silent destruction.** If a PR exists but its branch was force-pushed and now diverges from main in unexpected ways, surface a warning, don't silently update the PR description.
+
+---
+
+## Behavioral spec
+
+`canopy ship [--feature X] [--draft] [--reviewers user1,user2] [--dry-run]`
+
+Pre: feature must have all repos pushed (commits exist on remote). If not, `ship` runs `push --set-upstream` first as part of the recipe — no separate command needed for the first ship.
+
+| Pre-condition (per repo in scope) | Behavior |
+|---|---|
+| No commits unique to feature branch (branch == main HEAD) | `{repo, status: "skipped", reason: "no commits ahead of main"}`. Don't open empty PR. |
+| Branch has unpushed commits | Run `push --set-upstream` first; on success, continue. |
+| No PR exists for branch | `gh pr create --base <default> --head <branch> --title "<linear-id?> <feature-title>" --body <generated>` (+ `--draft` if flag, `--reviewer ...` if flag). Returns `{repo, status: "opened", pr_number, url}`. |
+| PR exists, head matches our pushed sha | `{repo, status: "up_to_date", pr_number, url}`. PRs auto-track branch — nothing to do. |
+| PR exists, head doesn't match (force-push divergence) | `{repo, status: "diverged", pr_number, url, warning: "PR head sha doesn't match local; manual review recommended"}`. Don't update the description. |
+| PR is closed/merged | `{repo, status: "closed", pr_number, url, reason: "PR is closed; manual reopen needed"}`. Don't open a new PR (that'd duplicate review history). |
+| Branch missing on remote | Push first (set-upstream), then create PR. |
+
+**Returns:** `{ feature, results: { <repo>: {status, pr_number?, url?, reason?, warning?} }, cross_repo_links_updated: bool }`.
+
+### PR title format
+
+`<LINEAR-ID> <feature title or feature name>`
+
+If feature has `linear_issue` set: `SIN-12 Add /search endpoint with shared filter types`. Else: just the feature name.
+
+### PR body template (auto-generated)
+
+```markdown
+[Linear: SIN-12](<linear-url>)
+
+This PR is part of the canopy feature `sin-12-search` (1 of 2 repos):
+
+- backend: this PR (#<this-number>)
+- frontend: <link to frontend PR>
+
+## Commits in this PR
+
+<bulleted list of commit subjects on the branch ahead of main>
+
+---
+
+🌳 Opened by [canopy](https://github.com/ashmitb95/canopy)
+```
+
+The cross-repo link section is what makes this primitive useful — reviewers see the related PRs without hunting. After ALL PRs are open, `ship` runs a second pass to update each PR's body with the *now-known* sibling PR numbers (initial open won't have them).
+
+---
+
+## State model changes
+
+None at the canopy layer. PRs are GitHub state, not canopy state. The dashboard's `reviewStatus` MCP tool already reads PR existence — `ship` just causes more PRs to exist.
+
+Optional (post-2.4 extension): cache `{feature, repo} → pr_number` in `.canopy/state/prs.json` so we can short-circuit the GitHub roundtrip when re-rendering the dashboard. Not required for 2.4; defer.
+
+---
+
+## Command surface changes
+
+| Today | After Wave 2.4 |
+|---|---|
+| `canopy ship` (does not exist) | New CLI command + MCP tool. |
+| `canopy review` | Unchanged (read-only PR status). |
+| `canopy preflight` | Unchanged. |
+| `canopy commit` / `canopy push` (Wave 2.3) | Unchanged; `ship` invokes `push` internally on first run. |
+
+---
+
+## Files to touch
+
+### New
+
+- `src/canopy/actions/ship.py` — orchestrator. Resolves canonical/explicit feature → for each repo: ensure-pushed → ensure-PR-exists → return result. Then runs the cross-repo description-update second pass.
+- `src/canopy/integrations/github_pr.py` — split out from existing `integrations/github.py` if it's getting fat. Implements `create_pr(repo, branch, base, title, body, draft, reviewers)`, `get_pr(repo, branch)`, `update_pr_body(repo, pr_number, body)`. MCP-first, gh-CLI fallback (existing pattern).
+- `tests/test_ship.py` — table-driven cases per row. Use the `gh` mock pattern from existing GitHub integration tests.
+
+### Modified
+
+- `src/canopy/cli/main.py` — `cmd_ship(args)`, dispatch + subparser.
+- `src/canopy/mcp/server.py` — register `@mcp.tool() ship(...)`.
+- `src/canopy/integrations/github.py` — if not splitting, add the three new functions here. Keep `BlockerError(code='github_not_configured')` semantics consistent with reads.
+- `docs/commands.md` — add `ship` section with example flow.
+- `docs/agents.md` — add to the workflow recipe ("preflight → commit → push → ship").
+- Both skill files — flag `ship` as the preferred way to open canopy-feature PRs.
+
+---
+
+## Tasks (rough sequence)
+
+### T1 — GitHub integration: PR create/get/update
+
+`integrations/github.py` (or `github_pr.py`) gets three functions:
+
+- `create_pr(repo, branch, base, title, body, draft=False, reviewers=None) -> {pr_number, url}` — uses MCP `create_pull_request` if configured, else `gh pr create --json number,url`.
+- `get_pr(repo, branch) -> {pr_number, url, head_sha, state} | None` — uses MCP `get_pull_request` or `gh pr view --json`.
+- `update_pr_body(repo, pr_number, body) -> None` — uses MCP `update_pull_request` or `gh pr edit --body`.
+
+All three swallow `not configured` into `BlockerError(code='github_not_configured', fix_actions: [...install GitHub MCP / gh CLI...])`.
+
+Tests: mock `gh` subprocess calls (existing pattern) + happy/blocker paths.
+
+### T2 — `actions/ship.py` orchestrator
+
+Resolve feature scope (canonical default; `--feature` override). For each repo in `lane.repos`:
+  1. Check if branch ahead of main (else skip with "no commits").
+  2. Check if pushed (else `push --set-upstream` via Wave 2.3 primitive).
+  3. Check if PR exists (`get_pr`); if no → `create_pr`; if yes → return current.
+  4. Append result row.
+
+Second pass: now that all `(repo, pr_number)` pairs are known, regenerate each PR body with cross-repo links and call `update_pr_body` for each repo where the body changed (i.e., this is the first `ship` for that PR).
+
+`--dry-run` populates the structured return without firing any state-changing call.
+
+Tests: workspace_with_feature + 2 repos + variants per pre-condition row.
+
+### T3 — CLI + MCP wrappers
+
+CLI prints a per-repo summary table (status / PR # / URL) on stdout; `--json` returns the structured dict. MCP tool returns `result.to_dict()` directly.
+
+### T4 — Cross-repo body regeneration
+
+The body template lives in `actions/ship.py:_render_body(feature_lane, repo, all_pr_numbers)`. Test it as a pure function — given a fixture lane + dict of pr_numbers, snapshot the rendered markdown.
+
+### T5 — Docs + skills
+
+- `docs/commands.md` — `ship` section with example invocation + sample output.
+- `docs/agents.md` — full workflow recipe (preflight → commit → push → ship; what each step adds).
+- Skill files — `ship` listed as the preferred way to open PRs across canopy features.
+
+---
+
+## Edge cases to remember
+
+- **Single-repo features.** Cross-repo link section in body collapses to "1 of 1 repos" — still useful as scaffolding.
+- **PR exists but for a different branch.** Shouldn't happen if branches are unique per feature, but if user manually opened a PR for `feature-name` from a different fork or branch, treat as `diverged` and warn.
+- **Reviewers don't exist.** `gh pr create --reviewer nobody` errors. Surface verbatim; don't drop reviewers silently.
+- **Drafts.** `--draft` flag on first ship; subsequent ships don't auto-undraft. Use `gh pr ready` (or future `canopy ship --ready`) for that — out of scope here.
+- **Network failures mid-pass.** If 2 of 3 PRs open and the 3rd network-fails, return a partial result. The user can re-run `ship` and the 2 already-open PRs return `up_to_date` while the 3rd retries. Idempotent.
+
+---
+
+## Out of scope
+
+- Auto-merging PRs after CI passes. Use `gh pr merge --auto` or a CI bot.
+- Reviewer assignment by team / CODEOWNERS. Reviewers come from `--reviewers` flag only.
+- Updating PR title after first ship. Title is set once; user edits manually if they change the feature name.
+- Shipping non-canopy features (random branches the user just created). `ship` operates only on canopy-tracked features.
+
+---
+
+## After this lands
+
+- The CLI workflow is end-to-end: `switch X` → edit → `preflight` → `commit -m` → `push` → `ship` → wait for review → repeat.
+- The dashboard's review section auto-detects the new PRs (existing `reviewStatus` watches GitHub).
+- The action drawer (Plan 5) gets a "Ship feature" button — even though it's not in the current mockup, it's the logical capstone.
+- The agent's `using-canopy` skill recipe collapses from a 5-step "use these MCP tools in this order" to a 2-step "commit + ship."

--- a/docs/plans/wave-2-4-ship.md
+++ b/docs/plans/wave-2-4-ship.md
@@ -1,3 +1,10 @@
+---
+status: queued
+priority: P2
+effort: ~2-3d
+depends_on: ["bot-tracking.md"]
+---
+
 # Wave 2.4 — `ship` as the canonical-feature delivery primitive
 
 ## Mental model

--- a/docs/plans/wave-4-draft-replies.md
+++ b/docs/plans/wave-4-draft-replies.md
@@ -1,3 +1,10 @@
+---
+status: queued
+priority: P2
+effort: ~2d
+depends_on: ["bot-tracking.md"]
+---
+
 # Wave 4 — `draft_replies` for addressed PR review threads
 
 ## Mental model

--- a/docs/plans/wave-4-draft-replies.md
+++ b/docs/plans/wave-4-draft-replies.md
@@ -1,0 +1,179 @@
+# Wave 4 — `draft_replies` for addressed PR review threads
+
+## Mental model
+
+When a reviewer leaves a comment like *"please rename `foo` to `bar`"* on a PR, the canopy workflow today is:
+
+1. User reads the comment in the dashboard's "Actionable threads" list.
+2. User edits the file in the worktree, renames `foo` → `bar`.
+3. User commits + pushes.
+4. **User manually goes to the PR, types "Done — renamed to `bar` in <commit-sha>", clicks Reply.**
+
+Step 4 is rote. The information needed to write that reply is all in the workspace:
+- The original comment text + file:line
+- The diff between the comment's commit and HEAD for that file
+- The commit sha(s) that touched the relevant lines
+
+`draft_replies` is the MCP tool that walks the open PR comments per repo, identifies which ones have been **addressed** (i.e., the file:line they reference has been modified in commits *after* the comment was posted), and emits a draft reply for each. The user reviews + posts (or edits + posts) — canopy doesn't auto-post.
+
+This is the load-bearing automation for the dashboard's "Address comments in Claude" / "Draft replies for addressed threads" actions.
+
+---
+
+## Behavioral spec
+
+`canopy draft_replies [--feature X] [--repo R] [--include-likely-resolved]`
+
+For each open PR in the feature's repos:
+
+1. Fetch all unresolved review comments (existing `review_comments` MCP tool already does this — reuse).
+2. For each comment:
+   a. Get the comment's `commit_id` (the sha at which the comment was made) and `path` + `line`.
+   b. Run `git log <commit_id>..HEAD -- <path>` to find commits that touched the file after the comment.
+   c. If any commits found, the comment is **addressed**.
+   d. For addressed comments, generate a draft reply (see template below).
+3. Return a structured list `{ feature, repos: { <repo>: { addressed: [<draft>, ...], unaddressed: [<comment>, ...] } } }`.
+
+`--include-likely-resolved` extends the addressed set with the existing temporal classifier's "likely_resolved_threads" (already computed by `review_filter`). These are weaker signal — comments that *seem* resolved by recent activity but didn't directly touch the file:line.
+
+### Draft format
+
+```python
+{
+    "comment_id": "...",
+    "comment_url": "https://github.com/.../pull/123#discussion_r456",
+    "original_comment": {
+        "author": "alice",
+        "path": "src/api/search.py",
+        "line": 18,
+        "body": "rename foo to bar",
+    },
+    "addressing_commits": [
+        {"sha": "abc123", "subject": "rename foo to bar in search", "date": "2026-04-25T10:00:00Z"},
+    ],
+    "draft_reply": "Done — renamed `foo` → `bar` in abc123.",
+    "confidence": "high",  # high / medium / low
+}
+```
+
+### Reply template
+
+The reply text is generated from a small set of patterns based on the comment text + addressing commit subject. Order of preference:
+
+1. **Specific commit subject match.** If the addressing commit's subject mentions the same identifier as the comment (e.g. comment says "rename foo to bar", commit subject says "rename foo to bar in search"), use: `Done — <commit subject>. (<sha>)`
+2. **Generic addressed.** Fallback: `Addressed in <sha>: <commit subject>.`
+3. **Multiple commits.** If 2+ commits address one comment: `Addressed across <N> commits — see <sha-list>.`
+
+The template is deliberately simple. **No LLM call** in v1. The user reviews the draft before posting; fancy NLP isn't worth the cost/latency for a draft they'll edit anyway. (Add LLM-augmented drafts in a future Wave 4.1 if user feedback says drafts are too rote.)
+
+`confidence`:
+- `high` — single commit, file:line touched directly, commit subject mentions same keyword as comment.
+- `medium` — single commit, file:line touched, no keyword match.
+- `low` — multiple commits, only line range touched (not exact line). Surface but warn.
+
+---
+
+## State model changes
+
+None. `draft_replies` is read-only — it generates text, doesn't post anything, doesn't update any canopy state files.
+
+---
+
+## Command surface changes
+
+| Today | After Wave 4 |
+|---|---|
+| `canopy draft_replies` (does not exist) | New CLI command + MCP tool. |
+| `canopy review` | Unchanged — read-only PR status. |
+| `canopy review-comments` (CLI) / `review_comments` (MCP) | Unchanged — returns raw unresolved comments. `draft_replies` consumes its output. |
+
+---
+
+## Files to touch
+
+### New
+
+- `src/canopy/actions/draft_replies.py` — orchestrator. Fetch comments → walk file history per comment → classify addressed vs unaddressed → generate drafts.
+- `tests/test_draft_replies.py` — fixture-driven cases:
+  - addressed by a single commit (high confidence)
+  - addressed by multiple commits (low confidence)
+  - unaddressed (file untouched since comment)
+  - addressed-but-no-keyword-match (medium confidence)
+  - comment on deleted file (status: addressed, confidence high, special template)
+
+### Modified
+
+- `src/canopy/cli/main.py` — `cmd_draft_replies(args)` + subparser.
+- `src/canopy/mcp/server.py` — register `@mcp.tool() draft_replies(...)`.
+- `src/canopy/git/repo.py` — extend with `log_for_path(repo_path, since_sha, path)` if not already there. Returns list of `{sha, subject, date}` for commits that touched `path` after `since_sha`.
+- `docs/commands.md` — `draft_replies` section.
+- `docs/agents.md` — add to the review-loop recipe.
+- Both skill files — list as a preferred tool when the agent is helping with PR comment triage.
+
+---
+
+## Tasks (rough sequence)
+
+### T1 — `git/repo.py` — file-history primitive
+
+`log_for_path(repo_path, since_sha, path) -> [{sha, subject, date}]`. Wraps `git -C <repo> log <since_sha>..HEAD --pretty=format:"%H|%s|%aI" -- <path>`. Empty list if no commits since.
+
+Tests in `tests/test_repo.py`: workspace_with_feature → modify file → assert log_for_path returns the modifying commit.
+
+### T2 — `actions/draft_replies.py` — classifier
+
+Pure function `classify_comment(comment, file_history) -> {status, confidence, addressing_commits}`. Status is `"addressed"` or `"unaddressed"`. Confidence per the rules above. No git calls; takes pre-fetched data.
+
+Tests: table-driven on the rule combinations.
+
+### T3 — `actions/draft_replies.py` — reply template
+
+Pure function `render_reply(original, addressing_commits, confidence) -> str`. The 3 template branches above.
+
+Tests: snapshot-style — given fixture inputs, assert exact output string. Catches accidental wording drift.
+
+### T4 — `actions/draft_replies.py` — orchestrator
+
+Compose: per repo → fetch unresolved comments → for each comment, call `log_for_path` → call `classify_comment` → if addressed, call `render_reply` → assemble result dict.
+
+Use the existing `actions/reads.py` helpers for the comment fetch (don't re-implement). Parallelize per repo via the existing `concurrent.futures` pattern.
+
+Tests: end-to-end with a fixture PR that has 3 comments (1 addressed by single commit, 1 addressed by multiple, 1 unaddressed). Assert returned shape.
+
+### T5 — CLI + MCP wrappers
+
+CLI prints a per-comment summary table on stdout (status / confidence / draft preview). `--json` returns structured dict. MCP tool returns `result.to_dict()`.
+
+### T6 — Docs + skills
+
+- `docs/commands.md` — example invocation + sample output.
+- `docs/agents.md` — review-loop recipe: `review_status` (find PRs) → `review_comments` (raw threads) → `draft_replies` (auto-draft addressed) → user posts → repeat.
+- Skill files — flag as preferred over manually walking file histories.
+
+---
+
+## Edge cases to remember
+
+- **Comment on deleted file.** `git log` against a deleted path still works (`git log -- <path>` shows the deletion commit). Treat the deleting commit as the addressing commit. Reply template: `Addressed by removing this file in <sha>.`
+- **Comment on renamed file.** `git log --follow -- <path>` to track across renames. Surface the rename in the addressing commit list (keep `--follow` on by default).
+- **Comment on a binary file.** Same logic — `git log` works on binary files; addressing means a commit modified them.
+- **Force-push erases the comment's commit_id.** If `git cat-file -e <comment_id>` fails, mark the comment `confidence: low`, status `unaddressed`, with a warning (`comment_commit_missing: true`). The user resolved it differently; canopy can't tell.
+- **Comment has no `commit_id`** (some legacy comments). Skip — return as `unaddressed` with `confidence: low`.
+- **Replies already exist on the thread.** Existing `review_comments` MCP tool filters to *unresolved* threads, so a thread with replies that resolved it is already excluded. No special handling needed here.
+
+---
+
+## Out of scope
+
+- Posting the drafts. `draft_replies` returns drafts; user (or a future "post replies" tool) posts them.
+- LLM-augmented drafts. Template-based v1; LLM as Wave 4.1 if the templates are too rigid in practice.
+- Cross-PR comment correlation (e.g. one comment that says "see also issue #123"). Out of scope.
+- Conversational threading (replying to specific reply within a thread). v1 emits one draft per top-level comment.
+
+---
+
+## After this lands
+
+- The dashboard's "Draft replies for addressed threads" button (Plan 5: action drawer) becomes wirable: click → call `draft_replies` → render the draft list in a modal → user reviews + clicks "Post all" or edits individually.
+- The CLI gives reviewers a one-shot way to triage their own addressed comments before re-requesting review.
+- The agent's review-loop becomes: find unresolved → check what's addressed → draft replies → suggest the user post them. Three MCP calls instead of N file-history walks.

--- a/docs/plans/worktree-bootstrap.md
+++ b/docs/plans/worktree-bootstrap.md
@@ -1,3 +1,10 @@
+---
+status: queued
+priority: P2
+effort: ~2d
+depends_on: ["doctor.md"]
+---
+
 # Worktree Bootstrap — env files, dep install, IDE workspace generation
 
 ## Why

--- a/docs/plans/worktree-bootstrap.md
+++ b/docs/plans/worktree-bootstrap.md
@@ -184,7 +184,7 @@ Add the `bootstrap` parameter through the three call sites. Default false (prese
 
 ## After this lands
 
-- A new contributor running `canopy worktree create <feature> --bootstrap` gets a ready-to-run dev environment in one command — env files in place, deps installed, IDE workspace open-able.
+- Running `canopy worktree create <feature> --bootstrap` produces a ready-to-run dev environment in one command — env files in place, deps installed, IDE workspace open-able.
 - The README failure-mode #5 (raw `git worktree add` mess) gets a stronger fix: not just predictable layout, but predictable readiness.
 - Canopy absorbs the workflow that was forcing teams to write per-monorepo bash wrappers (like the docsum `manage-worktrees` skill) and reframes it as configurable canopy infrastructure.
 - The `using-canopy` skill becomes more recommendation-able to monorepo teams who would otherwise reach for one-off scripts.

--- a/docs/plans/worktree-bootstrap.md
+++ b/docs/plans/worktree-bootstrap.md
@@ -1,0 +1,183 @@
+# Worktree Bootstrap — env files, dep install, IDE workspace generation
+
+## Why
+
+A new feature worktree is functionally a fresh checkout: branch is set, files are populated, but the developer-facing scaffolding is missing.
+
+- The repo's `.env` / `.env.local` aren't there (gitignored, didn't follow the worktree).
+- `node_modules/` / `.venv/` / equivalent isn't there — the worktree is a separate working tree, deps don't carry over.
+- IDEs that key off a `.code-workspace` / `.idea/` / `Cargo.toml` workspace file need one written, especially when multiple repos compose the feature.
+
+Without this, the user does the same three steps every time they spin up a worktree: copy the env file, run the install command, hand-edit the workspace file. The docsum `manage-worktrees` skill (a docsum-specific bash wrapper around `git worktree add`) handles all three. Canopy currently does none of them. This plan absorbs the capability — opt-in, configurable per repo, doesn't run unless asked.
+
+Distinct from the broader `manage-worktrees` skill which is hardcoded to two repos and disabled for agent invocation; canopy's version is generic over `repos[*]` in `canopy.toml` and runs from any context (CLI, MCP, extension).
+
+---
+
+## Behavioral spec
+
+### Three optional bootstrap steps, gated per repo + per invocation
+
+When canopy creates a fresh worktree for a feature (either via `canopy worktree create` or implicitly via `canopy switch` warming a cold feature), each step is **off by default** and runs only when:
+
+1. The relevant config is set in `canopy.toml` for that repo, AND
+2. The user passed `--bootstrap` (or set `bootstrap_default = true` in `[workspace]`).
+
+Step 1 — **Env file copy**
+
+Per repo, `env_files = [".env", ".env.local", "apps/web/.env.local"]` lists files (paths relative to repo root) to copy from the main checkout into the new worktree. Subdirectory paths are honored. Missing source files log a `[canopy] env-file missing: …` warning and are skipped — never blocking. Existing destination files aren't overwritten without `--force-bootstrap`.
+
+Step 2 — **Dependency install**
+
+Per repo, `install_cmd = "uv sync"` (or `"pnpm install"`, `"npm ci"`, `"poetry install"`, `"cargo build"`, etc.) runs in the new worktree directory. Stdout/stderr stream to the canopy output channel; exit code surfaces in the structured per-repo result. Failure doesn't roll back the worktree — the worktree is still valid; the user can fix and re-run `canopy worktree bootstrap <feature>` (new subcommand below).
+
+Step 3 — **IDE workspace file**
+
+Workspace-level `[workspace]` config `ide = "vscode"` triggers generation of `<workspace_root>/.canopy/workspaces/<feature>.code-workspace` listing every worktree dir for the feature, plus per-folder settings (e.g., `python.defaultInterpreterPath` pointing at the worktree's `.venv/bin/python`). Layout templated per IDE; v1 supports `vscode` only (`.code-workspace` JSON), with `none` (default) skipping. Future: `jetbrains` (`.idea/`), `cursor` (same as vscode).
+
+### New CLI surface
+
+- `canopy worktree create <feature> --bootstrap` — explicit bootstrap on create.
+- `canopy switch <feature> --bootstrap` — bootstrap when warming a cold feature (no-op when the target was already warm).
+- `canopy worktree bootstrap <feature>` — re-run all three steps against an existing worktree, idempotent. Useful when env files were updated, deps added, or `canopy.toml` config was extended after the worktree existed.
+- `canopy worktree bootstrap <feature> --step env|deps|ide` — run just one step, for the case where deps install is slow and you only need to refresh env.
+
+### Config additions
+
+`canopy.toml`:
+
+```toml
+[workspace]
+name = "my-product"
+ide = "vscode"                     # NEW — "vscode" | "none" (default)
+bootstrap_default = false          # NEW — if true, --bootstrap is implicit on create/warm
+
+[[repos]]
+name = "api"
+path = "./api"
+env_files = [".env", ".env.local"]                     # NEW — list of paths relative to repo
+install_cmd = "uv sync"                                 # NEW — single shell command, run in worktree dir
+ide_settings = { python = ".venv/bin/python" }          # NEW — kv map merged into the IDE workspace's per-folder settings
+
+[[repos]]
+name = "ui"
+path = "./ui"
+env_files = [".env.local", "apps/web/.env.local"]
+install_cmd = "pnpm install"
+```
+
+All three new fields on `RepoConfig` are optional. Workspaces that don't set them are unaffected.
+
+### Idempotency rules
+
+- Env-file copy: skip if destination exists (warn). With `--force-bootstrap`, overwrite.
+- Dep install: always runs; the install command is responsible for its own idempotency (`uv sync`, `pnpm install`, etc. are idempotent in practice).
+- IDE workspace file: regenerated each time. The file is fully owned by canopy. Don't hand-edit; put per-folder overrides in `repos[*].ide_settings`.
+
+### Failure model
+
+Per-step structured result so the orchestrator can report cleanly:
+
+```python
+{
+  "feature": "auth-flow",
+  "results": {
+    "<repo>": {
+      "env": {"status": "ok" | "skipped" | "missing_source", "files_copied": [...]},
+      "deps": {"status": "ok" | "failed" | "skipped", "exit_code": int, "duration_ms": int},
+    }
+  },
+  "ide": {"status": "ok" | "skipped" | "no_ide_configured", "path": "..."}
+}
+```
+
+`canopy worktree bootstrap --json` returns this shape directly. Failure of any step doesn't block the others — they're independent.
+
+---
+
+## Files to touch
+
+### New
+
+- `src/canopy/actions/bootstrap.py` — orchestrator. Public functions: `bootstrap_feature(workspace, feature, force=False, steps=None)`, `bootstrap_repo(workspace, feature, repo, force=False, steps=None)`. Composes the three steps; aggregates the structured result.
+- `src/canopy/actions/ide_workspace.py` — pure renderer: given a feature lane + per-repo `ide_settings`, returns the JSON for a `.code-workspace` file. Easy to unit-test as a string-in / dict-out pure function.
+- `tests/test_bootstrap.py` — table-driven cases per matrix above (env exists / missing source / install fails / IDE not configured).
+- `tests/test_ide_workspace.py` — snapshot test the rendered `.code-workspace` JSON for representative lane shapes.
+
+### Modified
+
+- `src/canopy/workspace/config.py` — add `RepoConfig.env_files: list[str]`, `RepoConfig.install_cmd: str`, `RepoConfig.ide_settings: dict[str, str]`, `WorkspaceConfig.ide: str`, `WorkspaceConfig.bootstrap_default: bool`. Default values keep existing workspaces forward-compatible.
+- `src/canopy/actions/evacuate.py` — when promoting a cold feature into a warm worktree, optionally invoke `bootstrap_repo` if `bootstrap_default=True` or the caller passed `--bootstrap`. Wire via a `bootstrap` parameter on `_evacuate_one`.
+- `src/canopy/actions/switch.py` — pass-through `bootstrap` flag to evacuate when warming a cold feature.
+- `src/canopy/features/coordinator.py` `worktree_create` — accept `bootstrap=True` and call `bootstrap_repo` post-creation.
+- `src/canopy/cli/main.py` — add `cmd_worktree_bootstrap`, wire `--bootstrap` flag on `cmd_switch` + `cmd_worktree_create`, register subparsers.
+- `src/canopy/mcp/server.py` — register `worktree_bootstrap(feature, force=False, steps=None)` tool.
+- `docs/commands.md` — new section.
+- `docs/workspace.md` — document the new `canopy.toml` keys.
+- `docs/agents.md` — note that the agent should call `worktree_bootstrap` after a cold feature warms (not auto-invoked, agent's choice).
+- Both skill files (`~/.claude/skills/using-canopy/SKILL.md` and `src/canopy/agent_setup/skill.md`) — flag bootstrap as an explicit step the agent can take.
+
+---
+
+## Tasks (rough sequence)
+
+### T1 — Config schema
+
+Extend `RepoConfig` and `WorkspaceConfig`. Update `parse_config` to accept and default the new fields. Tests in `test_config.py` covering: legacy toml parses unchanged; new fields parse; missing fields default empty/false.
+
+### T2 — Env-file copy primitive
+
+`actions/bootstrap.py:_copy_env_files(workspace, repo, src_dir, dst_dir, force)`. Iterates `repo.env_files`, copies each (preserving relative path inside the repo), reports per-file status. Pure file-system; tests use temp dirs.
+
+### T3 — Dep install primitive
+
+`actions/bootstrap.py:_run_install(repo, dst_dir, output_channel)`. Wraps `subprocess.Popen` to stream stdout to the output channel, captures exit code + duration. Tests mock subprocess.
+
+### T4 — IDE workspace renderer + writer
+
+`actions/ide_workspace.py` — pure renderer + atomic writer (write to tmp, rename). Snapshot tests on the rendered JSON.
+
+### T5 — `bootstrap_feature` / `bootstrap_repo` orchestrators
+
+Compose the three steps. Per-repo parallelism via the existing `concurrent.futures` pattern. Aggregate into the structured result. Tests cover the matrix.
+
+### T6 — Wire into `evacuate` + `switch` + `worktree_create`
+
+Add the `bootstrap` parameter through the three call sites. Default false (preserves existing behavior). Tests assert: `--bootstrap` triggers the steps; absence of flag leaves the worktree untouched.
+
+### T7 — CLI subparser + MCP tool registration
+
+`canopy worktree bootstrap <feature>`, `--bootstrap` flag on `switch` and `worktree create`, `--step` flag on `worktree bootstrap`. MCP `worktree_bootstrap` tool.
+
+### T8 — Docs + skills
+
+`docs/commands.md`, `docs/workspace.md`, `docs/agents.md`. Both skill files updated with the new tool listed in the preferred-over table.
+
+---
+
+## Edge cases to remember
+
+- **Symlinked env files.** If `repo/.env` is a symlink (some workflows), copy follows the link by default. Document as expected behavior.
+- **Multi-app repos.** docsum-ui has `apps/web/.env.local` AND `apps/word-addin/.env.local`. Both listed in `env_files`. Subdirs honored.
+- **Install command needs network.** `uv sync` / `pnpm install` may fail offline. Surface stderr in the result; don't retry.
+- **IDE workspace conflict.** If the user has an existing hand-written `.code-workspace` at the same path, canopy refuses to overwrite without `--force-bootstrap`. Canopy-managed workspaces live at `.canopy/workspaces/<feature>.code-workspace` — namespaced — but the user might point IDE settings at a different path. Don't overwrite anything outside `.canopy/`.
+- **`bootstrap` during `switch` of an active-rotation cycle.** When X evacuates → Y warms, do we bootstrap Y? Yes if Y was cold (warming = first time worktree exists). No if Y was already warm (worktree exists, env files already there). The `bootstrap_repo` function checks worktree state and short-circuits the env step accordingly.
+- **Parallel `bootstrap` runs.** Each repo's install command runs in its own subprocess; they're parallel-safe (no shared state). Tests assert thread-safety of the result aggregation.
+
+---
+
+## Out of scope
+
+- **Generating the install command from language inference.** v1 is opt-in via `install_cmd`; we don't infer "this is python ergo `uv sync`". Future helper: `canopy worktree detect-bootstrap <feature>` proposes a config based on what files exist (`pyproject.toml` → `uv sync`, `package.json` → `pnpm install`, etc.).
+- **Watching env files in the main checkout for changes.** If the user updates `.env` in main, the warm worktrees don't auto-update. They'd run `canopy worktree bootstrap <feature> --step env --force` to refresh. Auto-watch is a future ergonomic.
+- **Alternative IDE formats.** v1 ships `vscode` only. JetBrains `.idea/`, `cursor` (different format from vscode despite the marketing), Helix, etc. — additive plans.
+- **Removing env files / deps on `canopy done`.** When a feature is archived, the worktree is removed (existing behavior). Env files inside the worktree go with it. No special cleanup needed.
+
+---
+
+## After this lands
+
+- A new contributor running `canopy worktree create <feature> --bootstrap` gets a ready-to-run dev environment in one command — env files in place, deps installed, IDE workspace open-able.
+- The README failure-mode #5 (raw `git worktree add` mess) gets a stronger fix: not just predictable layout, but predictable readiness.
+- Canopy absorbs the workflow that was forcing teams to write per-monorepo bash wrappers (like the docsum `manage-worktrees` skill) and reframes it as configurable canopy infrastructure.
+- The `using-canopy` skill becomes more recommendation-able to monorepo teams who would otherwise reach for one-off scripts.


### PR DESCRIPTION
## Summary

Migrates canopy's roadmap and per-feature plan files from local-only (`~/.claude/plans/`) to in-tree at `docs/plans/`, with an epic dashboard at `docs/plans/INDEX.md` for live milestone tracking.
