### PR TITLE
M3: bot-comment tracking + commit --address + awaiting_bot_resolution state

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -29,7 +29,10 @@ src/canopy/
 │   ├── active_feature.py    # .canopy/state/active_feature.json reader/writer + last_touched LRU
 │   ├── drift.py             # detect_drift + assert_aligned (cached path)
 │   ├── evacuate.py          # WAVE 2.9: per-repo evacuate primitive (stash → wt-add → pop)
-│   ├── feature_state.py     # 8-state machine, dashboard backend (live git, worktree-aware)
+│   ├── feature_state.py     # 9-state machine, dashboard backend (live git, worktree-aware)
+│   ├── bot_resolutions.py   # M3: persistent log of bot comments addressed via `commit --address`
+│   ├── bot_status.py        # M3: per-feature bot-comment rollup
+│   ├── augments.py          # M2: per-workspace augment resolver (preflight_cmd, review_bots, ...)
 │   ├── preflight_state.py   # records preflight result for state machine
 │   ├── reads.py             # 4 alias-aware read primitives
 │   ├── realign.py           # internal helper used by switch (deprecated from CLI/MCP in Wave 2.9)
@@ -50,7 +53,7 @@ src/canopy/
 │   ├── github.py            # GitHub PR + comments (MCP or gh CLI fallback)
 │   └── precommit.py         # detect + run pre-commit hooks
 └── mcp/
-    ├── server.py            # MCP server — 41 tools, stdio transport
+    ├── server.py            # MCP server — 49 tools, stdio transport
     └── client.py            # MCP client — stdio + HTTP+OAuth transports
 ```
 
@@ -95,7 +98,7 @@ For integration testing against real services, see `~/projects/canopy-test/` (me
 - **Action contract:** `actions/protocol.py` (planned) will formalize the per-repo `{status, before, after, reason?}` shape. For now, each action returns it ad-hoc.
 - **Skill bundling:** Bundled skills live at `src/canopy/agent_setup/skills/<name>/SKILL.md`. `canopy setup-agent` copies them to `~/.claude/skills/<name>/SKILL.md`. The default `using-canopy` skill always installs; opt-in extras (e.g. `augment-canopy`) install via `--skill <name>` (repeatable). Foreign skills with the same path are not overwritten without `--reinstall`. The `_SKILL_SOURCE` constant remains as a backward-compat alias pointing at `using-canopy`'s source.
 
-## MCP Server (43 tools)
+## MCP Server (49 tools)
 
 Grouped by topic. Run with `canopy-mcp` (entry point) or `python -m canopy.mcp.server`.
 

--- a/docs/agents.md
+++ b/docs/agents.md
@@ -6,7 +6,7 @@ How AI coding agents (Claude Code primarily; others by analogy) integrate with c
 
 Three pieces, all installed in one step by `canopy init`:
 
-1. **Canopy MCP server** (`canopy-mcp` binary) — 41 tools exposing every canopy operation. Registered in `<workspace>/.mcp.json`.
+1. **Canopy MCP server** (`canopy-mcp` binary) — 49 tools exposing every canopy operation. Registered in `<workspace>/.mcp.json`.
 2. **`using-canopy` skill** at `~/.claude/skills/using-canopy/SKILL.md` — tells the agent *when* to prefer canopy MCP over raw bash.
 3. **Per-workspace MCP config** in `<workspace>/.mcp.json` with `CANOPY_ROOT` set so the server scopes to the right workspace.
 

--- a/docs/commands.md
+++ b/docs/commands.md
@@ -18,7 +18,7 @@ Organized by **workflow stage** — top to bottom matches a typical day.
 | Command | What it does |
 |---|---|
 | `canopy triage [--author @me]` | Prioritized list of features needing attention. Groups open PRs across repos by feature, sorts by review state (`changes_requested` > `review_required_with_bot_comments` > `review_required` > `approved`). Use this every morning. |
-| `canopy state <feature>` | The 8-state machine for one feature, plus the suggested `next_actions`. Same JSON the dashboard renders. |
+| `canopy state <feature>` | The 9-state machine for one feature, plus the suggested `next_actions`. Same JSON the dashboard renders. |
 | `canopy drift [<feature>]` | Per-feature alignment from `.canopy/state/heads.json` (the post-checkout hook's data). Fast, hook-driven. Doesn't touch git directly. |
 | `canopy list` | Compact feature overview — names, Linear links, per-repo branch/dirty/ahead-behind. |
 | `canopy status` | Per-repo branch + dirty + divergence from default branch. |
@@ -52,7 +52,8 @@ Write actions and execution.
 | `canopy run <repo> <command> [--feature]` | Run a shell command in a canopy-managed repo with cwd resolved internally. The "agent never `cd`s" tool — also useful from a CLI in a deeply nested directory. |
 | `canopy code\|cursor\|fork <feature\|.>` | Open the feature in VS Code / Cursor / Fork.app (alias-aware; generates `.code-workspace` for the IDE ones). |
 | `canopy sync` | Pull default branch + rebase feature branches across repos. |
-| `canopy commit -m <msg> [--feature <f>] [--repo <r,...>] [--paths <p ...>] [--no-hooks] [--amend]` | **Wave 2.3.** Commit across every repo in the canonical (or named) feature with a single message. Defaults to canonical feature. Pre-flight refuses with `BlockerError(code='wrong_branch')` if any in-scope repo has drifted; per-repo hook failures don't cancel the others (status: `hooks_failed` for the failing repo). |
+| `canopy commit -m <msg> [--feature <f>] [--repo <r,...>] [--paths <p ...>] [--no-hooks] [--amend] [--address <id>]` | **Wave 2.3 + M3.** Commit across every repo in the canonical (or named) feature with a single message. Pre-flight refuses with `BlockerError(code='wrong_branch')` if any in-scope repo has drifted; per-repo hook failures don't cancel the others (status: `hooks_failed`). `--address <comment-id>` (numeric id or GitHub URL) auto-suffixes the message with the bot comment's title + URL and records the resolution in `.canopy/state/bot_resolutions.json`. Non-bot comments raise `BlockerError(code='not_a_bot_comment')`. |
+| `canopy bot-status [--feature <f>] [--unresolved-only]` | **M3.** Per-feature rollup of bot review comments — total / resolved / unresolved per repo + an `all_resolved` flag. Bot vs human classification respects `[augments] review_bots` in canopy.toml. |
 | `canopy push [--feature <f>] [--repo <r,...>] [--set-upstream] [--force-with-lease] [--dry-run]` | **Wave 2.3.** Push the feature branch in every in-scope repo. Pre-flight raises `BlockerError(code='no_upstream')` if any repo lacks an upstream and `--set-upstream` was not passed; the fix-action carries the same args + `--set-upstream` so an agent retries mechanically. Per-repo statuses: `ok`, `up_to_date`, `rejected`, `failed`. |
 
 ## Verify

--- a/docs/concepts.md
+++ b/docs/concepts.md
@@ -64,20 +64,23 @@ Every read tool accepts the same alias forms. Learn one rule, use everywhere:
 
 For features whose branch differs across repos (e.g., `SIN-13-fixes` in backend, `SIN-13-fixes-v2` in frontend — common when one side rebases or renames mid-flight), the lane's `branches` map handles it transparently. You pass the canonical feature alias; canopy resolves per-repo branches.
 
-## 3. The 8-state machine
+## 3. The 9-state machine
 
-`canopy state <feature>` (and the MCP tool `feature_state(feature)`) returns one of 8 states + an ordered `next_actions` array. Same data the [VSCode extension](https://marketplace.visualstudio.com/items?itemName=SingularityInc.canopy) dashboard renders.
+`canopy state <feature>` (and the MCP tool `feature_state(feature)`) returns one of 9 states + an ordered `next_actions` array. Same data the [VSCode extension](https://marketplace.visualstudio.com/items?itemName=SingularityInc.canopy) dashboard renders.
 
 | State | Detection | Primary `next_actions` |
 |---|---|---|
 | **`drifted`** | live `current_branch` ≠ expected for any repo in the lane | `switch(feature)` (canonical-slot model — handles both worktree and main-tree cases) |
-| **`needs_work`** | clean + (CHANGES_REQUESTED or actionable comments) | `address_review_comments(feature)` |
+| **`needs_work`** | clean + (CHANGES_REQUESTED or actionable human comments) | `address_review_comments(feature)` |
 | **`in_progress`** | aligned + dirty + no fresh preflight | `preflight(feature)` |
 | **`ready_to_commit`** | aligned + dirty + preflight passed for current HEAD | `commit(feature)` |
 | **`ready_to_push`** | aligned + clean + ahead of remote | `push(feature)` |
+| **`awaiting_bot_resolution`** (M3) | clean + PR open + no human signal + ≥1 unresolved bot comment | `address_bot_comments(feature)` → `commit --address <id>` |
 | **`awaiting_review`** | aligned + clean + PRs open + no actionable threads | refresh / wait |
-| **`approved`** | all PRs APPROVED | `merge` |
+| **`approved`** | all PRs APPROVED | `merge` (+ secondary `address_bot_comments` if bot threads remain) |
 | **`no_prs`** | aligned + clean + no PRs anywhere | `pr_create(feature)` |
+
+**Bot vs human comment classification** (M3): a comment counts as a bot when GitHub reports `author_type == "Bot"`. With `[augments] review_bots = ["coderabbit", ...]` set in canopy.toml, the author also has to substring-match the configured list — so an unconfigured bot account drops out of bot tracking and stays in the human bucket. Resolved bot comments (those addressed via `canopy commit --address <id>`) are subtracted from `actionable_bot_count`. Bot nits never gate `approved`; human approval is the merge gate.
 
 Detection uses **live git state** (not the cached `.canopy/state/heads.json`) for correctness — even if the post-checkout hook hasn't fired, `feature_state` is right. The hook + `heads.json` exist to power `canopy drift`'s fast path.
 
@@ -104,6 +107,9 @@ Detection uses **live git state** (not the cached `.canopy/state/heads.json`) fo
         │                                │                 │
         │                                push              │
         │                                │                 │
+        │                                ▼                 │
+        │                          awaiting_bot_resolution ── (only bot nits
+        │                                │                     unresolved)
         │                                ▼                 │
         │                          awaiting_review ───── (manual git checkout
         │                                │                 elsewhere = drift)

--- a/docs/mcp.md
+++ b/docs/mcp.md
@@ -57,7 +57,8 @@ Grouped by topic. Every tool is alias-aware where it accepts a feature input.
 | `feature_paths` | Working directory paths per repo |
 | `feature_done` | Clean up worktrees + branches + archive |
 | `feature_link_linear` | Attach a Linear issue to a feature |
-| `feature_state` | **Dashboard backend.** Returns `{state, summary, next_actions, warnings}`. State ∈ `{drifted, needs_work, in_progress, ready_to_commit, ready_to_push, awaiting_review, approved, no_prs}`. See [concepts.md](concepts.md#3-the-8-state-machine). |
+| `feature_state` | **Dashboard backend.** Returns `{state, summary, next_actions, warnings}`. State ∈ `{drifted, needs_work, in_progress, ready_to_commit, ready_to_push, awaiting_bot_resolution, awaiting_review, approved, no_prs}`. The `summary` carries split `actionable_human_count` + `actionable_bot_count` (M3). See [concepts.md](concepts.md#3-the-9-state-machine). |
+| `bot_comments_status` | **M3.** Per-feature rollup of bot review comments — `{feature, repos: {<repo>: {pr_number, total, resolved, unresolved, threads}}, all_resolved, any_bot_comments}`. Resolutions come from the persistent log written by `commit --address`. |
 
 #### Action (Wave 2)
 

--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -2,7 +2,7 @@
 
 Live status of canopy's planned work. Update this file as milestones progress; each plan's frontmatter is the per-plan source of truth, this doc is the rolled-up dashboard.
 
-**Last updated:** 2026-05-02 (M0, M1, M2, M5 shipped)
+**Last updated:** 2026-05-02 (M0, M1, M2, M5 shipped; M3 in-progress)
 **Roadmap:** [roadmap.md](roadmap.md) — full architecture context, cross-cutting decisions, sequencing rationale
 
 ## Status legend
@@ -26,7 +26,7 @@ Live status of canopy's planned work. Update this file as milestones progress; e
 
 - [x] ✅ **M2 — Augment skill** — [archive/augments.md](archive/augments.md) · shipped 2026-05-02
   Per-workspace `[augments]` block in canopy.toml + opt-in `augment-canopy` skill. Wires `preflight_cmd`; reserves `review_bots` (M3) and `test_cmd` (future).
-- [ ] 🟦 **M3 — Bot-comment tracking** — [bot-tracking.md](bot-tracking.md) · P1 · ~3d · depends on M2
+- [ ] 🟨 **M3 — Bot-comment tracking** — [bot-tracking.md](bot-tracking.md) · P1 · ~3d · depends on M2
   Distinguish bot vs human review comments, `commit --address <id>`, new `awaiting_bot_resolution` state.
 - [ ] 🟦 **M4 — Historian** — [historian.md](historian.md) · P1 · ~5-6d · depends on M3
   Cross-session feature memory at `.canopy/memory/<feature>.md`. Auto-read on `canopy switch`.

--- a/docs/plans/bot-tracking.md
+++ b/docs/plans/bot-tracking.md
@@ -1,5 +1,5 @@
 ---
-status: queued
+status: in-progress
 priority: P1
 effort: ~3d
 depends_on: ["augments.md"]

--- a/src/canopy/actions/bot_resolutions.py
+++ b/src/canopy/actions/bot_resolutions.py
@@ -1,0 +1,123 @@
+"""Persistent log of bot review-comments addressed by canopy commits (M3).
+
+State file: ``<workspace_root>/.canopy/state/bot_resolutions.json``
+
+Schema (an append-only mapping; each key is a stringified GitHub comment ID)::
+
+    {
+      "123456": {
+        "feature": "sin-6-cache-stats",
+        "repo": "test-api",
+        "commit_sha": "abc123de",
+        "addressed_at": "2026-05-02T17:30:00Z",
+        "comment_title": "rename hit_rate to cache_hit_rate",
+        "comment_url": "https://github.com/owner/repo/pull/142#discussion_r123456"
+      }
+    }
+
+Written by ``commit --address``; read by the ``bot_comments_status`` rollup
+and by ``feature_state`` to subtract resolved bot comments from the
+actionable count surfaced in the agent dashboard.
+
+Writes are atomic (temp file + ``os.replace``) so concurrent record calls
+across worktrees don't corrupt the file.
+"""
+from __future__ import annotations
+
+import json
+import os
+import tempfile
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Any
+
+
+_STATE_DIR = ".canopy/state"
+_STATE_FILE = "bot_resolutions.json"
+
+
+def _state_path(workspace_root: Path) -> Path:
+    return workspace_root / _STATE_DIR / _STATE_FILE
+
+
+def _now_iso() -> str:
+    return datetime.now(timezone.utc).strftime("%Y-%m-%dT%H:%M:%SZ")
+
+
+def load_resolutions(workspace_root: Path) -> dict[str, dict[str, Any]]:
+    """Read the resolution log. Returns an empty dict when no file exists."""
+    path = _state_path(workspace_root)
+    if not path.exists():
+        return {}
+    try:
+        with open(path, "r") as f:
+            data = json.load(f)
+    except (json.JSONDecodeError, OSError):
+        return {}
+    return data if isinstance(data, dict) else {}
+
+
+def is_resolved(workspace_root: Path, comment_id: str | int) -> bool:
+    """True iff this comment id is in the resolution log."""
+    return str(comment_id) in load_resolutions(workspace_root)
+
+
+def resolutions_for_feature(
+    workspace_root: Path, feature: str,
+) -> dict[str, dict[str, Any]]:
+    """Filter the log to entries tagged with this feature name."""
+    return {
+        cid: entry
+        for cid, entry in load_resolutions(workspace_root).items()
+        if entry.get("feature") == feature
+    }
+
+
+def record_resolution(
+    workspace_root: Path,
+    *,
+    comment_id: str | int,
+    feature: str,
+    repo: str,
+    commit_sha: str,
+    comment_title: str,
+    comment_url: str = "",
+    addressed_at: str | None = None,
+) -> dict[str, Any]:
+    """Append a resolution entry. Last-write-wins on duplicate comment_id.
+
+    Returns the entry written. Creates the state directory if missing.
+    """
+    path = _state_path(workspace_root)
+    path.parent.mkdir(parents=True, exist_ok=True)
+
+    existing = load_resolutions(workspace_root)
+    entry = {
+        "feature": feature,
+        "repo": repo,
+        "commit_sha": commit_sha,
+        "addressed_at": addressed_at or _now_iso(),
+        "comment_title": comment_title,
+        "comment_url": comment_url,
+    }
+    existing[str(comment_id)] = entry
+    _atomic_write(path, existing)
+    return entry
+
+
+def _atomic_write(path: Path, data: dict) -> None:
+    """Write JSON atomically: tmp file in same dir, then os.replace."""
+    fd, tmp = tempfile.mkstemp(
+        prefix=f".{path.name}.", suffix=".tmp", dir=str(path.parent),
+    )
+    try:
+        with os.fdopen(fd, "w") as f:
+            json.dump(data, f, indent=2, sort_keys=True)
+            f.write("\n")
+        os.replace(tmp, path)
+    except Exception:
+        try:
+            os.unlink(tmp)
+        except FileNotFoundError:
+            pass
+        raise

--- a/src/canopy/actions/bot_status.py
+++ b/src/canopy/actions/bot_status.py
@@ -1,0 +1,133 @@
+"""Per-feature bot-comment rollup (M3).
+
+Composes the live actionable bot threads (from ``feature_state._per_repo_facts``)
+with the persistent resolution log (``bot_resolutions.json``) into a single
+``{feature, repos: {<repo>: {pr_number, total, resolved, unresolved, threads}},
+all_resolved}`` shape that the CLI / MCP / dashboard share.
+
+A "bot comment" here means an actionable thread whose author was classified as
+a bot per ``feature_state._is_bot_comment`` (GitHub-typed bot AND, when
+``review_bots`` is set in canopy.toml augments, substring-matching the
+configured list).
+"""
+from __future__ import annotations
+
+from typing import Any
+
+from . import active_feature as af
+from .aliases import repos_for_feature, resolve_feature
+from .bot_resolutions import resolutions_for_feature
+from .errors import BlockerError, FixAction
+from .feature_state import _per_repo_facts, resolve_repo_paths
+from ..workspace.workspace import Workspace
+
+
+def bot_comments_status(
+    workspace: Workspace,
+    feature: str | None = None,
+) -> dict[str, Any]:
+    """Build the rollup. Falls back to the canonical feature when ``feature`` is None."""
+    feature_name = _resolve_feature_name(workspace, feature)
+    repo_branches = repos_for_feature(workspace, feature_name)
+    if not repo_branches:
+        raise BlockerError(
+            code="empty_feature",
+            what=f"feature '{feature_name}' has no associated repos",
+        )
+
+    repo_paths, _has_wt = resolve_repo_paths(workspace, feature_name, repo_branches)
+    facts = _per_repo_facts(workspace, feature_name, repo_branches, repo_paths)
+    resolutions = resolutions_for_feature(workspace.config.root, feature_name)
+
+    repos_out: dict[str, dict[str, Any]] = {}
+    all_resolved = True
+    any_bot_comment_seen = False
+
+    for repo_name, repo_facts in facts.items():
+        pr = repo_facts.get("pr") or {}
+        bot_threads = repo_facts.get("actionable_bot_threads", [])
+        # Resolution entries scoped to this repo (so we report a sensible
+        # `resolved` count per PR even when other repos have their own).
+        repo_resolutions = {
+            cid: entry
+            for cid, entry in resolutions.items()
+            if entry.get("repo") == repo_name
+        }
+        unresolved_threads = [
+            _thread_summary(t, resolved=False, resolution=None) for t in bot_threads
+        ]
+        resolved_threads = [
+            _resolved_summary(cid, entry)
+            for cid, entry in sorted(repo_resolutions.items())
+        ]
+        threads = resolved_threads + unresolved_threads
+
+        total = len(threads)
+        if total > 0:
+            any_bot_comment_seen = True
+        if unresolved_threads:
+            all_resolved = False
+
+        repos_out[repo_name] = {
+            "pr_number": pr.get("number"),
+            "pr_url": pr.get("url", ""),
+            "total": total,
+            "resolved": len(resolved_threads),
+            "unresolved": len(unresolved_threads),
+            "threads": threads,
+        }
+
+    return {
+        "feature": feature_name,
+        "repos": repos_out,
+        "all_resolved": all_resolved if any_bot_comment_seen else True,
+        "any_bot_comments": any_bot_comment_seen,
+    }
+
+
+def _resolve_feature_name(workspace: Workspace, feature: str | None) -> str:
+    if feature:
+        return resolve_feature(workspace, feature)
+    active = af.read_active(workspace)
+    if active is None:
+        raise BlockerError(
+            code="no_canonical_feature",
+            what="no active feature; pass --feature or run `canopy switch <name>` first",
+            fix_actions=[
+                FixAction(action="switch", args={}, safe=False,
+                          preview="canopy switch <feature> sets the canonical slot"),
+            ],
+        )
+    return active.feature
+
+
+def _thread_summary(
+    thread: dict, *, resolved: bool, resolution: dict | None,
+) -> dict[str, Any]:
+    out = {
+        "id": thread.get("id"),
+        "author": thread.get("author", ""),
+        "path": thread.get("path", ""),
+        "line": thread.get("line", 0),
+        "url": thread.get("url", ""),
+        "body_preview": (thread.get("body") or "").splitlines()[0][:120] if thread.get("body") else "",
+        "resolved": resolved,
+    }
+    if resolution:
+        out["resolved_by_commit"] = resolution.get("commit_sha", "")
+        out["addressed_at"] = resolution.get("addressed_at", "")
+    return out
+
+
+def _resolved_summary(comment_id: str, entry: dict) -> dict[str, Any]:
+    return {
+        "id": comment_id,
+        "author": "",
+        "path": "",
+        "line": 0,
+        "url": entry.get("comment_url", ""),
+        "body_preview": entry.get("comment_title", ""),
+        "resolved": True,
+        "resolved_by_commit": entry.get("commit_sha", ""),
+        "addressed_at": entry.get("addressed_at", ""),
+    }

--- a/src/canopy/actions/commit.py
+++ b/src/canopy/actions/commit.py
@@ -21,9 +21,15 @@ Per-repo recipe::
 
 Per-repo failure does NOT cancel other repos. Result aggregates the
 per-repo outcome dict so the caller can act on partial success.
+
+The ``--address <comment-id>`` flag (M3) auto-formats the commit message
+with a bot comment's title + URL and records a resolution entry in
+``.canopy/state/bot_resolutions.json`` when the matching repo commits
+successfully.
 """
 from __future__ import annotations
 
+import re
 from pathlib import Path
 from typing import Any
 
@@ -31,8 +37,9 @@ from ..git import repo as git
 from ..workspace.workspace import Workspace
 from . import active_feature as af
 from .aliases import repos_for_feature, resolve_feature
+from .bot_resolutions import record_resolution
 from .errors import BlockerError, FixAction
-from .feature_state import resolve_repo_paths
+from .feature_state import _per_repo_facts, resolve_repo_paths
 
 
 def _resolve_feature_name(
@@ -171,13 +178,15 @@ def commit(
     paths: list[str] | None = None,
     no_hooks: bool = False,
     amend: bool = False,
+    address: str | None = None,
 ) -> dict[str, Any]:
     """Commit across every repo in a feature lane.
 
     Args:
         workspace: the workspace.
-        message: commit message (required; empty messages should be
-            rejected at the CLI parse layer before reaching here).
+        message: commit message (required unless ``amend`` or ``address``
+            supplies one). Empty messages should be rejected at the CLI
+            parse layer before reaching here.
         feature: feature alias. If None, falls back to the canonical
             feature in ``active_feature.json``.
         repos: optional filter — only commit in these repos within
@@ -187,19 +196,20 @@ def commit(
             If given, ``git add <paths>`` instead of ``git add -u``.
         no_hooks: skip pre-commit / commit-msg hooks (``--no-verify``).
         amend: amend HEAD instead of creating a new commit.
+        address: a bot review comment ID or its GitHub URL (M3). When
+            set, the commit message is auto-suffixed with the comment
+            title + URL, and on success the resolution is recorded in
+            ``.canopy/state/bot_resolutions.json``. Comment must belong
+            to one of the feature's actionable bot threads; a non-bot
+            comment raises ``BlockerError(code='not_a_bot_comment')``.
 
-    Returns ``{feature, results: {<repo>: {...}}}``. The per-repo dict
-    has shape ``{status, sha?, files_changed?, reason?, hook_output?,
-    amended?}`` where ``status`` is one of
-    ``ok | nothing | hooks_failed | failed``.
+    Returns ``{feature, results: {<repo>: {...}}, addressed?}``. The
+    per-repo dict has shape ``{status, sha?, files_changed?, reason?,
+    hook_output?, amended?}`` where ``status`` is one of
+    ``ok | nothing | hooks_failed | failed``. When ``--address`` is given
+    and a resolution was recorded, ``addressed`` carries
+    ``{comment_id, repo, sha, title, url}``.
     """
-    if not message and not amend:
-        # CLI argparse should catch this, but guard for direct callers.
-        raise BlockerError(
-            code="empty_message",
-            what="commit message is required",
-        )
-
     feature_name = _resolve_feature_name(workspace, feature)
     repo_branches = repos_for_feature(workspace, feature_name)
     if not repo_branches:
@@ -223,6 +233,47 @@ def commit(
 
     repo_paths, _has_wt = resolve_repo_paths(workspace, feature_name, repo_branches)
 
+    # ── --address: locate the bot comment and rewrite the message ───────
+    addressed_info: dict[str, Any] | None = None
+    if address is not None:
+        comment_id = _parse_comment_id(address)
+        bot_comment, owning_repo = _find_actionable_bot_comment(
+            workspace, feature_name, repo_branches, repo_paths, comment_id,
+        )
+        if bot_comment is None:
+            raise BlockerError(
+                code="not_a_bot_comment",
+                what=(
+                    f"comment {comment_id} is not in any actionable bot thread for "
+                    f"feature '{feature_name}'"
+                ),
+                details={
+                    "feature": feature_name,
+                    "comment_id": comment_id,
+                    "hint": (
+                        "verify the id with `canopy bot-status --feature "
+                        f"{feature_name}` and pass either the numeric id or "
+                        "the comment URL"
+                    ),
+                },
+            )
+        title = _comment_title(bot_comment.get("body", ""))
+        url = bot_comment.get("url", "")
+        message = _format_address_message(message or "", title, url)
+        addressed_info = {
+            "comment_id": comment_id,
+            "repo": owning_repo,
+            "title": title,
+            "url": url,
+        }
+
+    if not message and not amend:
+        # CLI argparse should catch this, but guard for direct callers.
+        raise BlockerError(
+            code="empty_message",
+            what="commit message is required",
+        )
+
     if amend:
         # Amend skips the wrong_branch pre-check — amending a commit on a
         # different branch is sometimes intentional (rebase aftermath).
@@ -241,4 +292,96 @@ def commit(
             amend=amend,
         )
 
-    return {"feature": feature_name, "results": results}
+    out: dict[str, Any] = {"feature": feature_name, "results": results}
+
+    # Record the resolution iff the owning repo committed successfully.
+    if addressed_info is not None:
+        owning = addressed_info["repo"]
+        owning_result = results.get(owning, {})
+        if owning_result.get("status") == "ok":
+            sha = owning_result["sha"]
+            record_resolution(
+                workspace.config.root,
+                comment_id=addressed_info["comment_id"],
+                feature=feature_name,
+                repo=owning,
+                commit_sha=sha,
+                comment_title=addressed_info["title"],
+                comment_url=addressed_info["url"],
+            )
+            addressed_info["sha"] = sha
+            addressed_info["recorded"] = True
+        else:
+            addressed_info["recorded"] = False
+            addressed_info["reason"] = (
+                f"owning repo '{owning}' commit status: {owning_result.get('status', 'unknown')}"
+            )
+        out["addressed"] = addressed_info
+
+    return out
+
+
+# ── --address helpers ────────────────────────────────────────────────────
+
+
+_TRAILING_DIGITS = re.compile(r"(\d+)\s*$")
+
+
+def _parse_comment_id(address: str) -> str:
+    """Accept a numeric id, a ``#123`` form, or a GitHub URL.
+
+    GitHub URLs end with ``#discussion_r<N>``, ``#issuecomment-<N>``, or
+    similar — we extract the trailing digit run as the canonical id.
+    """
+    raw = address.strip()
+    match = _TRAILING_DIGITS.search(raw)
+    if not match:
+        raise BlockerError(
+            code="invalid_comment_id",
+            what=f"could not parse a comment id from '{address}'",
+            details={"hint": "pass a numeric id (e.g. 123456) or the GitHub comment URL"},
+        )
+    return match.group(1)
+
+
+def _find_actionable_bot_comment(
+    workspace: Workspace,
+    feature_name: str,
+    repo_branches: dict[str, str],
+    repo_paths: dict[str, Path],
+    comment_id: str,
+) -> tuple[dict | None, str | None]:
+    """Walk per-repo bot threads for a matching comment id.
+
+    Returns ``(comment_dict, owning_repo)`` or ``(None, None)`` when no
+    actionable bot thread carries the requested id.
+    """
+    facts = _per_repo_facts(workspace, feature_name, repo_branches, repo_paths)
+    for repo_name, repo_facts in facts.items():
+        for thread in repo_facts.get("actionable_bot_threads", []):
+            if str(thread.get("id", "")) == comment_id:
+                return thread, repo_name
+    return None, None
+
+
+def _comment_title(body: str, max_len: int = 80) -> str:
+    """First non-empty line of the comment, trimmed to ``max_len``."""
+    for line in (body or "").splitlines():
+        line = line.strip()
+        if not line:
+            continue
+        if len(line) <= max_len:
+            return line
+        return line[:max_len].rstrip() + "…"
+    return ""
+
+
+def _format_address_message(user_message: str, title: str, url: str) -> str:
+    """Append the standard ``Addresses bot comment`` trailer."""
+    suffix_parts = [f'Addresses bot comment: "{title}"' if title else "Addresses bot comment"]
+    if url:
+        suffix_parts[-1] += f" ({url})"
+    suffix = "\n\n".join(suffix_parts)
+    if user_message.strip():
+        return f"{user_message.rstrip()}\n\n{suffix}"
+    return suffix

--- a/src/canopy/actions/feature_state.py
+++ b/src/canopy/actions/feature_state.py
@@ -31,6 +31,8 @@ from ..workspace.workspace import Workspace
 from .aliases import (
     repos_for_feature, resolve_feature, _resolve_owner_slug,
 )
+from .augments import bot_authors
+from .bot_resolutions import resolutions_for_feature
 from .preflight_state import is_fresh
 from .review_filter import classify_threads
 
@@ -191,6 +193,9 @@ def _per_repo_facts(
         facts["repo_slug"] = slug
         facts["pr"] = None
         facts["actionable_count"] = 0
+        facts["actionable_human_count"] = 0
+        facts["actionable_bot_count"] = 0
+        facts["actionable_bot_threads"] = []
         facts["likely_resolved_count"] = 0
         facts["review_decision"] = ""
         if owner and slug:
@@ -208,13 +213,53 @@ def _per_repo_facts(
                         workspace.config.root, owner, slug, pr["number"],
                     )
                     classification = classify_threads(comments, repo_path, branch)
-                    facts["actionable_count"] = len(classification["actionable_threads"])
-                    facts["likely_resolved_count"] = len(classification["likely_resolved_threads"])
+                    actionable = classification["actionable_threads"]
+                    facts["likely_resolved_count"] = len(
+                        classification["likely_resolved_threads"],
+                    )
+                    bot_subs = bot_authors(workspace.config)
+                    resolved_ids = set(
+                        resolutions_for_feature(
+                            workspace.config.root, feature_name,
+                        ).keys()
+                    )
+                    bot_threads = [
+                        t for t in actionable
+                        if _is_bot_comment(t, bot_subs)
+                        and str(t.get("id", "")) not in resolved_ids
+                    ]
+                    human_threads = [
+                        t for t in actionable
+                        if not _is_bot_comment(t, bot_subs)
+                    ]
+                    facts["actionable_human_count"] = len(human_threads)
+                    facts["actionable_bot_count"] = len(bot_threads)
+                    facts["actionable_bot_threads"] = bot_threads
+                    facts["actionable_count"] = (
+                        facts["actionable_human_count"] + facts["actionable_bot_count"]
+                    )
                 except Exception:
                     pass
 
         out[repo_name] = facts
     return out
+
+
+def _is_bot_comment(comment: dict, bot_substrings: list[str]) -> bool:
+    """Determine if a normalized review comment came from a bot.
+
+    With ``review_bots`` configured (M2 augment), require both
+    ``author_type == "Bot"`` AND a substring match against the configured
+    list. Without it, fall back to the GitHub-provided ``author_type``
+    alone — so unconfigured workspaces still benefit from basic bot
+    detection.
+    """
+    author_type = (comment.get("author_type") or "").lower()
+    is_typed_bot = author_type == "bot"
+    if not bot_substrings:
+        return is_typed_bot
+    author = (comment.get("author") or "").lower()
+    return is_typed_bot and any(sub in author for sub in bot_substrings)
 
 
 def _summarize(per_repo: dict[str, dict]) -> dict[str, Any]:
@@ -223,6 +268,12 @@ def _summarize(per_repo: dict[str, dict]) -> dict[str, Any]:
         r: f.get("ahead", 0) for r, f in per_repo.items() if f.get("ahead", 0) > 0
     }
     actionable_total = sum(f.get("actionable_count", 0) for f in per_repo.values())
+    actionable_human_total = sum(
+        f.get("actionable_human_count", 0) for f in per_repo.values()
+    )
+    actionable_bot_total = sum(
+        f.get("actionable_bot_count", 0) for f in per_repo.values()
+    )
     likely_resolved_total = sum(
         f.get("likely_resolved_count", 0) for f in per_repo.values()
     )
@@ -234,10 +285,12 @@ def _summarize(per_repo: dict[str, dict]) -> dict[str, Any]:
         "dirty_repos": dirty_repos,
         "ahead_repos": ahead_repos,
         "actionable_count": actionable_total,
+        "actionable_human_count": actionable_human_total,
+        "actionable_bot_count": actionable_bot_total,
         "likely_resolved_count": likely_resolved_total,
         "review_decisions": decisions,
         "pr_count": pr_count,
-        "repos": {r: {k: v for k, v in f.items() if k != "pr"}
+        "repos": {r: {k: v for k, v in f.items() if k not in ("pr", "actionable_bot_threads")}
                    for r, f in per_repo.items()},
         "prs": {r: f["pr"] for r, f in per_repo.items() if f.get("pr")},
     }
@@ -263,6 +316,8 @@ def _decide_state(
 ) -> tuple[str, list[dict], list[dict]]:
     decisions = summary["review_decisions"]
     actionable = summary["actionable_count"]
+    actionable_human = summary.get("actionable_human_count", actionable)
+    actionable_bot = summary.get("actionable_bot_count", 0)
     dirty = bool(summary["dirty_repos"])
     ahead = bool(summary["ahead_repos"])
     pr_count = summary["pr_count"]
@@ -315,12 +370,15 @@ def _decide_state(
         return "ready_to_push", next_actions, warnings
 
     # Aligned, clean, caught up to remote (or nothing to push).
-    if actionable > 0 or _any_changes_requested(decisions):
+    # Human signals (CHANGES_REQUESTED reviews, or actionable human threads)
+    # block on `needs_work`; bot threads alone route to `awaiting_bot_resolution`.
+    if actionable_human > 0 or _any_changes_requested(decisions):
         next_actions = [
             {"action": "address_review_comments",
              "args": {"feature": feature_name},
              "primary": True, "label": "Address review comments",
-             "preview": f"{actionable} actionable thread(s)"},
+             "preview": f"{actionable_human} human thread(s), {actionable_bot} bot thread(s)"
+                          if actionable_bot else f"{actionable_human} human thread(s)"},
             {"action": "comments", "args": {"feature": feature_name},
              "primary": False, "label": "View comments"},
         ]
@@ -341,7 +399,31 @@ def _decide_state(
              "primary": True, "label": "Merge",
              "preview": "all PRs approved (manual or via UI)"},
         ]
+        # Bots may still have unresolved nits — surface as a non-gating
+        # secondary CTA. State stays `approved` (human approval is the merge
+        # gate; bot nits are a side-channel).
+        if actionable_bot > 0:
+            next_actions.append({
+                "action": "address_bot_comments",
+                "args": {"feature": feature_name},
+                "primary": False, "label": "Address bot comments",
+                "preview": f"{actionable_bot} unresolved bot thread(s)",
+            })
         return "approved", next_actions, warnings
+
+    # No human action pending, PR open, not yet approved. Bot nits get their
+    # own state so the agent + dashboard can distinguish "still review-pending"
+    # from "human is silent but bots flagged things."
+    if actionable_bot > 0:
+        next_actions = [
+            {"action": "address_bot_comments",
+             "args": {"feature": feature_name},
+             "primary": True, "label": "Address bot comments",
+             "preview": f"{actionable_bot} bot thread(s)"},
+            {"action": "comments", "args": {"feature": feature_name},
+             "primary": False, "label": "View comments"},
+        ]
+        return "awaiting_bot_resolution", next_actions, warnings
 
     next_actions = [
         {"action": "refresh", "args": {"feature": feature_name},

--- a/src/canopy/agent_setup/skills/using-canopy/SKILL.md
+++ b/src/canopy/agent_setup/skills/using-canopy/SKILL.md
@@ -92,6 +92,14 @@ The `mcp__canopy__version` tool returns `{cli_version, mcp_version, schema_versi
 
 If the user wants canopy to behave differently here — *"use ruff for preflight"*, *"track CodeRabbit and Korbit as bots"*, *"the api repo runs `uv run pytest tests/fast` before commits"* — that's a **canopy.toml augment**. Suggest invoking the `augment-canopy` skill, which knows the schema and how to mutate the file safely. Install it with `canopy setup-agent --skill augment-canopy` if it isn't already.
 
+## Bot review comments
+
+When `mcp__canopy__feature_state` returns state `awaiting_bot_resolution`, only bot nits (CodeRabbit, Korbit, Cubic, etc.) are blocking — humans haven't requested changes. The `summary` splits the actionable count into `actionable_bot_count` and `actionable_human_count` so you can tell which side needs attention.
+
+- `mcp__canopy__bot_comments_status(feature)` returns the per-PR rollup: total / resolved / unresolved + per-thread metadata (id, author, file, body preview).
+- `mcp__canopy__commit(message, address=<comment-id>)` (or `canopy commit --address <id>`) auto-suffixes the commit message with the bot comment's title + URL and persists the resolution to `.canopy/state/bot_resolutions.json`. Resolved comments drop out of `actionable_bot_count` on the next `feature_state` call.
+- Address one comment per commit so the resolution log stays granular and the agent's next `bot-status` call has clean per-comment provenance.
+
 ## Anti-patterns
 
 - ❌ `cd <repo> && git checkout <branch>` — use `mcp__canopy__switch(feature=...)` so all participating repos move together with verification (and the previously-canonical feature evacuates to a warm worktree, preserving its work-in-progress).

--- a/src/canopy/cli/main.py
+++ b/src/canopy/cli/main.py
@@ -2145,12 +2145,13 @@ def cmd_commit(args: argparse.Namespace) -> None:
         with spinner(spin_msg):
             result = commit_impl(
                 workspace,
-                args.message,
+                args.message or "",
                 feature=args.feature,
                 repos=_split_csv(args.repos),
                 paths=args.paths or None,
                 no_hooks=args.no_hooks,
                 amend=args.amend,
+                address=getattr(args, "address", None),
             )
     except ActionError as err:
         if args.json:
@@ -2180,6 +2181,72 @@ def cmd_commit(args: argparse.Namespace) -> None:
                 console.print(f"        [muted]{line}[/]")
         else:  # failed
             console.print(f"    [error]✗[/] [repo]{repo}[/]  {r.get('reason', 'failed')}")
+    addressed = result.get("addressed")
+    if addressed:
+        cid = addressed["comment_id"]
+        if addressed.get("recorded"):
+            sha = (addressed.get("sha") or "")[:8]
+            console.print(
+                f"    [success]✓[/] addressed bot comment [muted]{cid}[/] "
+                f"(recorded against [repo]{addressed['repo']}[/] {sha})",
+            )
+        else:
+            console.print(
+                f"    [warning]·[/] bot comment [muted]{cid}[/] not recorded "
+                f"({addressed.get('reason', 'no successful commit in owning repo')})",
+            )
+    console.print()
+
+
+def cmd_bot_status(args: argparse.Namespace) -> None:
+    """Per-feature bot-comment rollup (M3)."""
+    from ..actions.bot_status import bot_comments_status
+    from ..actions.errors import ActionError
+    from .render import render_blocker
+    from .ui import console
+
+    workspace = _load_workspace()
+    try:
+        result = bot_comments_status(workspace, feature=args.feature)
+    except ActionError as err:
+        if args.json:
+            _print_json(err.to_dict())
+        else:
+            render_blocker(err, action="bot-status")
+        sys.exit(1)
+
+    if args.json:
+        _print_json(result)
+        return
+
+    console.print()
+    console.print(f"  [feature]{result['feature']}[/]")
+    if not result["any_bot_comments"]:
+        console.print("    [muted]no bot comments tracked[/]")
+        console.print()
+        return
+
+    for repo, info in result["repos"].items():
+        if info["total"] == 0:
+            continue
+        glyph = "[success]✓[/]" if info["unresolved"] == 0 else "[warning]●[/]"
+        pr = f"PR #{info['pr_number']}" if info.get("pr_number") else "no PR"
+        console.print(
+            f"    {glyph} [repo]{repo}[/]  {pr}  "
+            f"resolved {info['resolved']}/{info['total']}",
+        )
+        threads = (
+            [t for t in info["threads"] if not t["resolved"]]
+            if args.unresolved_only
+            else info["threads"]
+        )
+        for t in threads:
+            mark = "[success]✓[/]" if t["resolved"] else "[warning]●[/]"
+            label = f"{t.get('author', '')}".strip() or "(unknown)"
+            preview = t.get("body_preview", "")
+            console.print(f"        {mark} [muted]{t.get('id', '')}[/] {label}: {preview}")
+    overall = "[success]all resolved[/]" if result["all_resolved"] else "[warning]unresolved[/]"
+    console.print(f"    [muted]→ {overall}[/]")
     console.print()
 
 
@@ -2711,7 +2778,7 @@ def main() -> None:
         "commit",
         help="Commit across every repo in the canonical (or named) feature",
     )
-    commit_p.add_argument("-m", "--message", required=True,
+    commit_p.add_argument("-m", "--message", required=False, default="",
                             help="Commit message (single message across all repos)")
     commit_p.add_argument("--feature", default=None,
                             help="Feature alias; defaults to canonical feature")
@@ -2723,7 +2790,22 @@ def main() -> None:
                             help="Pass --no-verify to skip pre-commit / commit-msg hooks")
     commit_p.add_argument("--amend", action="store_true",
                             help="Amend HEAD in each repo instead of creating new commits")
+    commit_p.add_argument("--address", default=None, metavar="COMMENT-ID",
+                            help="Address a bot review comment (numeric id or GitHub URL); "
+                                 "auto-suffixes the message with the comment title + URL "
+                                 "and records the resolution in .canopy/state/bot_resolutions.json")
     commit_p.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # bot-status — per-feature bot-comment rollup (M3)
+    bot_status_p = subparsers.add_parser(
+        "bot-status",
+        help="Show bot review comments for the canonical (or named) feature",
+    )
+    bot_status_p.add_argument("--feature", default=None,
+                                help="Feature alias; defaults to canonical feature")
+    bot_status_p.add_argument("--unresolved-only", action="store_true",
+                                help="Only list unresolved threads")
+    bot_status_p.add_argument("--json", action="store_true", help="Output as JSON")
 
     # push (feature-scoped multi-repo push — Wave 2.3)
     push_p = subparsers.add_parser(
@@ -2919,6 +3001,7 @@ def main() -> None:
         "comments": cmd_comments,
         "switch": cmd_switch,
         "commit": cmd_commit,
+        "bot-status": cmd_bot_status,
         "push": cmd_push,
         "triage": cmd_triage,
         "state": cmd_state,

--- a/src/canopy/integrations/github.py
+++ b/src/canopy/integrations/github.py
@@ -535,6 +535,7 @@ def _normalize_comments(data: Any) -> tuple[list[dict], int]:
             author_type = ""
 
         normalized.append({
+            "id": c.get("id"),                          # M3: stable id for `commit --address`
             "path": c.get("path") or c.get("file") or "",
             "line": c.get("line") or c.get("original_line") or c.get("position") or 0,
             "body": c.get("body") or "",

--- a/src/canopy/mcp/server.py
+++ b/src/canopy/mcp/server.py
@@ -250,9 +250,10 @@ def switch(feature: str, release_current: bool = False,
 
 
 @mcp.tool()
-def commit(message: str, feature: str | None = None,
+def commit(message: str = "", feature: str | None = None,
            repos: list[str] | None = None, paths: list[str] | None = None,
-           no_hooks: bool = False, amend: bool = False) -> dict:
+           no_hooks: bool = False, amend: bool = False,
+           address: str | None = None) -> dict:
     """Commit across every repo in a feature lane with a single message (Wave 2.3).
 
     Defaults to the canonical feature when ``feature`` is omitted (reads
@@ -263,6 +264,12 @@ def commit(message: str, feature: str | None = None,
     branch. Mismatches raise ``BlockerError(code='wrong_branch')`` with
     a per-repo expected/actual map; no commits fire.
 
+    ``address`` (M3): a bot review comment id (numeric or GitHub URL).
+    When set, the message is auto-suffixed with the comment title + URL
+    and a resolution is recorded in ``.canopy/state/bot_resolutions.json``
+    against the matching repo's commit SHA. Non-bot comments raise
+    ``BlockerError(code='not_a_bot_comment')``.
+
     Per-repo result statuses:
       - ``ok``           — committed; carries ``sha``, ``files_changed``.
       - ``nothing``      — no changes staged.
@@ -270,8 +277,8 @@ def commit(message: str, feature: str | None = None,
                             tail of ``hook_output``. Other repos continue.
       - ``failed``       — git error (gpg, locked index, etc.).
 
-    Returns ``{feature, results: {<repo>: {...}}}`` on success, or a
-    structured ``BlockerError``-shaped dict on pre-flight rejection.
+    Returns ``{feature, results: {<repo>: {...}}, addressed?}`` on success,
+    or a structured ``BlockerError``-shaped dict on pre-flight rejection.
     """
     from ..actions.commit import commit as _impl
     from ..actions.errors import ActionError
@@ -280,8 +287,27 @@ def commit(message: str, feature: str | None = None,
         return _impl(
             ws, message,
             feature=feature, repos=repos, paths=paths,
-            no_hooks=no_hooks, amend=amend,
+            no_hooks=no_hooks, amend=amend, address=address,
         )
+    except ActionError as e:
+        return e.to_dict()
+
+
+@mcp.tool()
+def bot_comments_status(feature: str | None = None) -> dict:
+    """Per-feature rollup of bot review comments (M3).
+
+    Returns ``{feature, repos: {<repo>: {pr_number, total, resolved,
+    unresolved, threads}}, all_resolved, any_bot_comments}``. Bot threads
+    are read live from open PRs; resolutions come from the persistent
+    ``.canopy/state/bot_resolutions.json`` log written by
+    ``commit --address``.
+    """
+    from ..actions.bot_status import bot_comments_status as _impl
+    from ..actions.errors import ActionError
+    ws = _get_workspace()
+    try:
+        return _impl(ws, feature=feature)
     except ActionError as e:
         return e.to_dict()
 

--- a/tests/test_bot_resolutions.py
+++ b/tests/test_bot_resolutions.py
@@ -1,0 +1,133 @@
+"""Tests for canopy.actions.bot_resolutions — persistence layer for M3."""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+from canopy.actions.bot_resolutions import (
+    is_resolved,
+    load_resolutions,
+    record_resolution,
+    resolutions_for_feature,
+)
+
+
+def _state_file(workspace_root: Path) -> Path:
+    return workspace_root / ".canopy" / "state" / "bot_resolutions.json"
+
+
+def test_load_returns_empty_when_no_file(tmp_path):
+    assert load_resolutions(tmp_path) == {}
+
+
+def test_record_then_load_round_trip(tmp_path):
+    record_resolution(
+        tmp_path,
+        comment_id=123456,
+        feature="sin-6",
+        repo="api",
+        commit_sha="abc123de",
+        comment_title="rename foo to bar",
+        comment_url="https://github.com/o/r/pull/1#discussion_r123456",
+    )
+    data = load_resolutions(tmp_path)
+    assert "123456" in data
+    entry = data["123456"]
+    assert entry["feature"] == "sin-6"
+    assert entry["repo"] == "api"
+    assert entry["commit_sha"] == "abc123de"
+    assert entry["comment_title"] == "rename foo to bar"
+    assert entry["comment_url"].endswith("123456")
+    assert entry["addressed_at"]   # ISO timestamp set
+
+
+def test_record_creates_state_directory(tmp_path):
+    assert not (tmp_path / ".canopy").exists()
+    record_resolution(
+        tmp_path,
+        comment_id=1, feature="f", repo="r", commit_sha="sha",
+        comment_title="t",
+    )
+    assert _state_file(tmp_path).exists()
+
+
+def test_record_supports_int_or_str_comment_id(tmp_path):
+    record_resolution(
+        tmp_path, comment_id=999, feature="f", repo="r",
+        commit_sha="x", comment_title="t",
+    )
+    record_resolution(
+        tmp_path, comment_id="888", feature="f", repo="r",
+        commit_sha="y", comment_title="t",
+    )
+    data = load_resolutions(tmp_path)
+    assert "999" in data and "888" in data
+
+
+def test_record_overwrites_on_duplicate_id(tmp_path):
+    record_resolution(
+        tmp_path, comment_id=1, feature="f", repo="r",
+        commit_sha="first", comment_title="initial",
+    )
+    record_resolution(
+        tmp_path, comment_id=1, feature="f", repo="r",
+        commit_sha="second", comment_title="re-addressed",
+    )
+    data = load_resolutions(tmp_path)
+    assert data["1"]["commit_sha"] == "second"
+    assert data["1"]["comment_title"] == "re-addressed"
+
+
+def test_is_resolved_true_after_record(tmp_path):
+    assert is_resolved(tmp_path, 42) is False
+    record_resolution(
+        tmp_path, comment_id=42, feature="f", repo="r",
+        commit_sha="x", comment_title="t",
+    )
+    assert is_resolved(tmp_path, 42) is True
+    assert is_resolved(tmp_path, "42") is True   # str/int both work
+
+
+def test_resolutions_for_feature_filters(tmp_path):
+    record_resolution(
+        tmp_path, comment_id=1, feature="alpha", repo="r",
+        commit_sha="x", comment_title="t",
+    )
+    record_resolution(
+        tmp_path, comment_id=2, feature="beta", repo="r",
+        commit_sha="y", comment_title="t",
+    )
+    record_resolution(
+        tmp_path, comment_id=3, feature="alpha", repo="r",
+        commit_sha="z", comment_title="t",
+    )
+    alpha_only = resolutions_for_feature(tmp_path, "alpha")
+    assert set(alpha_only.keys()) == {"1", "3"}
+
+
+def test_load_returns_empty_on_corrupt_file(tmp_path):
+    state = _state_file(tmp_path)
+    state.parent.mkdir(parents=True, exist_ok=True)
+    state.write_text("{ this is not valid json")
+    assert load_resolutions(tmp_path) == {}
+
+
+def test_persisted_file_is_pretty_json(tmp_path):
+    record_resolution(
+        tmp_path, comment_id=1, feature="f", repo="r",
+        commit_sha="x", comment_title="t",
+    )
+    raw = _state_file(tmp_path).read_text()
+    # indent=2 + sort_keys → human-diffable
+    assert "\n" in raw
+    parsed = json.loads(raw)
+    assert "1" in parsed
+
+
+def test_addressed_at_can_be_overridden_for_deterministic_tests(tmp_path):
+    record_resolution(
+        tmp_path, comment_id=1, feature="f", repo="r",
+        commit_sha="x", comment_title="t",
+        addressed_at="2026-05-02T17:30:00Z",
+    )
+    assert load_resolutions(tmp_path)["1"]["addressed_at"] == "2026-05-02T17:30:00Z"

--- a/tests/test_bot_status.py
+++ b/tests/test_bot_status.py
@@ -1,0 +1,159 @@
+"""Tests for canopy.actions.bot_status — per-feature bot-comment rollup (M3)."""
+from __future__ import annotations
+
+import json
+import subprocess
+from unittest.mock import patch
+
+import pytest
+
+from canopy.actions.bot_resolutions import record_resolution
+from canopy.actions.bot_status import bot_comments_status
+from canopy.actions.errors import BlockerError
+from canopy.workspace.config import RepoConfig, WorkspaceConfig
+from canopy.workspace.workspace import Workspace
+
+
+def _make_workspace(workspace_dir):
+    config = WorkspaceConfig(
+        name="test",
+        repos=[RepoConfig(name="repo-a", path="./repo-a", role="x", lang="x")],
+        root=workspace_dir,
+    )
+    return Workspace(config)
+
+
+def _features_file(workspace_dir, payload):
+    canopy_dir = workspace_dir / ".canopy"
+    canopy_dir.mkdir(exist_ok=True)
+    (canopy_dir / "features.json").write_text(json.dumps(payload))
+
+
+def _set_remote(repo_path, url):
+    subprocess.run(
+        ["git", "remote", "add", "origin", url],
+        cwd=repo_path, check=True, capture_output=True, text=True,
+    )
+
+
+def _bot_comment(comment_id, *, body="rename foo to bar"):
+    return {
+        "id": comment_id, "path": "src/auth.py", "line": 1, "body": body,
+        "author": "coderabbit", "author_type": "Bot", "state": "",
+        "created_at": "2030-01-01T00:00:00Z",
+        "url": f"https://github.com/o/r/pull/1#discussion_r{comment_id}",
+        "in_reply_to_id": None,
+    }
+
+
+def _pr():
+    return {"number": 142, "title": "x", "url": "u", "state": "open",
+            "head_branch": "auth-flow", "base_branch": "main", "body": "",
+            "review_decision": "REVIEW_REQUIRED", "mergeable": "", "draft": False}
+
+
+def test_status_empty_when_no_pr_no_resolutions(workspace_with_feature):
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},
+    })
+    _set_remote(workspace_with_feature / "repo-a", "git@github.com:owner/repo-a.git")
+    ws = _make_workspace(workspace_with_feature)
+
+    with patch("canopy.actions.feature_state.gh.find_pull_request",
+               return_value=None), \
+         patch("canopy.actions.feature_state.gh.get_review_comments",
+               return_value=([], 0)):
+        result = bot_comments_status(ws, feature="auth-flow")
+
+    assert result["feature"] == "auth-flow"
+    assert result["any_bot_comments"] is False
+    assert result["all_resolved"] is True   # vacuously true
+    assert result["repos"]["repo-a"]["total"] == 0
+
+
+def test_status_all_unresolved(workspace_with_feature):
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},
+    })
+    _set_remote(workspace_with_feature / "repo-a", "git@github.com:owner/repo-a.git")
+    ws = _make_workspace(workspace_with_feature)
+
+    with patch("canopy.actions.feature_state.gh.find_pull_request",
+               return_value=_pr()), \
+         patch("canopy.actions.feature_state.gh.get_review_comments",
+               return_value=([_bot_comment(1), _bot_comment(2)], 0)):
+        result = bot_comments_status(ws, feature="auth-flow")
+
+    repo_info = result["repos"]["repo-a"]
+    assert repo_info["pr_number"] == 142
+    assert repo_info["total"] == 2
+    assert repo_info["resolved"] == 0
+    assert repo_info["unresolved"] == 2
+    assert result["all_resolved"] is False
+    assert result["any_bot_comments"] is True
+
+
+def test_status_mixed_resolved_unresolved(workspace_with_feature):
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},
+    })
+    _set_remote(workspace_with_feature / "repo-a", "git@github.com:owner/repo-a.git")
+    ws = _make_workspace(workspace_with_feature)
+
+    record_resolution(
+        workspace_with_feature, comment_id=1, feature="auth-flow",
+        repo="repo-a", commit_sha="abc12345", comment_title="addressed already",
+        comment_url="https://github.com/o/r/pull/1#discussion_r1",
+    )
+
+    with patch("canopy.actions.feature_state.gh.find_pull_request",
+               return_value=_pr()), \
+         patch("canopy.actions.feature_state.gh.get_review_comments",
+               return_value=([_bot_comment(2)], 0)):
+        result = bot_comments_status(ws, feature="auth-flow")
+
+    repo_info = result["repos"]["repo-a"]
+    assert repo_info["resolved"] == 1
+    assert repo_info["unresolved"] == 1
+    assert repo_info["total"] == 2
+    assert result["all_resolved"] is False
+
+    threads_by_id = {str(t["id"]): t for t in repo_info["threads"]}
+    assert threads_by_id["1"]["resolved"] is True
+    assert threads_by_id["1"]["resolved_by_commit"] == "abc12345"
+    assert threads_by_id["2"]["resolved"] is False
+
+
+def test_status_all_resolved_when_resolutions_match_open_threads(workspace_with_feature):
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},
+    })
+    _set_remote(workspace_with_feature / "repo-a", "git@github.com:owner/repo-a.git")
+    ws = _make_workspace(workspace_with_feature)
+
+    record_resolution(
+        workspace_with_feature, comment_id=42, feature="auth-flow",
+        repo="repo-a", commit_sha="sha", comment_title="t",
+    )
+
+    # Live API returns the same comment (still on the PR), but we've recorded it.
+    with patch("canopy.actions.feature_state.gh.find_pull_request",
+               return_value=_pr()), \
+         patch("canopy.actions.feature_state.gh.get_review_comments",
+               return_value=([_bot_comment(42)], 0)):
+        result = bot_comments_status(ws, feature="auth-flow")
+
+    repo_info = result["repos"]["repo-a"]
+    assert repo_info["unresolved"] == 0
+    assert repo_info["resolved"] == 1
+    assert result["all_resolved"] is True
+
+
+def test_status_blocker_when_no_canonical_feature(workspace_with_feature):
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},
+    })
+    ws = _make_workspace(workspace_with_feature)
+    with pytest.raises(BlockerError) as excinfo:
+        bot_comments_status(ws, feature=None)
+    assert excinfo.value.code == "no_canonical_feature"

--- a/tests/test_commit.py
+++ b/tests/test_commit.py
@@ -257,3 +257,178 @@ def test_commit_empty_message_raises(workspace_with_feature):
     with pytest.raises(BlockerError) as exc:
         commit(ws, "", feature="auth-flow")
     assert exc.value.code == "empty_message"
+
+
+# ── --address (M3): bot-comment resolution ──────────────────────────────
+
+
+from unittest.mock import patch
+from canopy.actions.bot_resolutions import is_resolved, load_resolutions
+from canopy.actions.commit import (
+    _format_address_message, _comment_title, _parse_comment_id,
+)
+
+
+def _bot_comment(comment_id, *, body="rename foo to bar"):
+    return {
+        "id": comment_id, "path": "src/auth.py", "line": 1, "body": body,
+        "author": "coderabbit", "author_type": "Bot", "state": "",
+        "created_at": "2030-01-01T00:00:00Z",
+        "url": f"https://github.com/o/r/pull/1#discussion_r{comment_id}",
+        "in_reply_to_id": None,
+    }
+
+
+def _set_remote(repo_path, url):
+    subprocess.run(
+        ["git", "remote", "add", "origin", url],
+        cwd=repo_path, check=True, capture_output=True, text=True,
+    )
+
+
+def _open_pr():
+    return {"number": 1, "title": "x", "url": "u", "state": "open",
+            "head_branch": "auth-flow", "base_branch": "main", "body": "",
+            "review_decision": "REVIEW_REQUIRED", "mergeable": "", "draft": False}
+
+
+# helper unit tests (module-private but worth pinning)
+
+
+def test_parse_comment_id_accepts_numeric():
+    assert _parse_comment_id("123456") == "123456"
+
+
+def test_parse_comment_id_accepts_hash_form():
+    assert _parse_comment_id("#789") == "789"
+
+
+def test_parse_comment_id_accepts_full_url():
+    url = "https://github.com/o/r/pull/142#discussion_r999"
+    assert _parse_comment_id(url) == "999"
+
+
+def test_parse_comment_id_rejects_garbage():
+    with pytest.raises(BlockerError) as exc:
+        _parse_comment_id("not-an-id")
+    assert exc.value.code == "invalid_comment_id"
+
+
+def test_comment_title_first_line():
+    assert _comment_title("first line\nsecond") == "first line"
+    assert _comment_title("") == ""
+
+
+def test_comment_title_truncates():
+    long_title = "a" * 200
+    out = _comment_title(long_title, max_len=50)
+    assert out.endswith("…")
+    assert len(out) == 51
+
+
+def test_format_address_message_with_user_message():
+    msg = _format_address_message("rename complete", "rename foo", "https://gh/c/1")
+    assert msg.startswith("rename complete")
+    assert 'Addresses bot comment: "rename foo" (https://gh/c/1)' in msg
+
+
+def test_format_address_message_without_user_message():
+    msg = _format_address_message("", "rename foo", "https://gh/c/1")
+    assert msg == 'Addresses bot comment: "rename foo" (https://gh/c/1)'
+
+
+# integration tests
+
+
+def test_commit_with_address_records_resolution(workspace_with_feature):
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},
+    })
+    _set_remote(workspace_with_feature / "repo-a", "git@github.com:owner/repo-a.git")
+    ws = _make_workspace(workspace_with_feature, repos=("repo-a",))
+
+    (workspace_with_feature / "repo-a" / "src" / "models.py").write_text(
+        "renamed\n"
+    )
+
+    with patch("canopy.actions.feature_state.gh.find_pull_request",
+               return_value=_open_pr()), \
+         patch("canopy.actions.feature_state.gh.get_review_comments",
+               return_value=([_bot_comment(123456)], 0)):
+        result = commit(
+            ws, "user message",
+            feature="auth-flow", address="123456",
+        )
+
+    assert result["results"]["repo-a"]["status"] == "ok"
+    addressed = result["addressed"]
+    assert addressed["comment_id"] == "123456"
+    assert addressed["recorded"] is True
+    assert addressed["sha"]   # has the commit sha
+    # Resolution persisted to disk
+    assert is_resolved(workspace_with_feature, 123456) is True
+    entry = load_resolutions(workspace_with_feature)["123456"]
+    assert entry["feature"] == "auth-flow"
+    assert entry["repo"] == "repo-a"
+
+
+def test_commit_with_address_accepts_url(workspace_with_feature):
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},
+    })
+    _set_remote(workspace_with_feature / "repo-a", "git@github.com:owner/repo-a.git")
+    ws = _make_workspace(workspace_with_feature, repos=("repo-a",))
+
+    (workspace_with_feature / "repo-a" / "src" / "app.py").write_text("changed\n")
+
+    url = "https://github.com/o/r/pull/1#discussion_r999"
+    with patch("canopy.actions.feature_state.gh.find_pull_request",
+               return_value=_open_pr()), \
+         patch("canopy.actions.feature_state.gh.get_review_comments",
+               return_value=([_bot_comment(999)], 0)):
+        result = commit(ws, "fix", feature="auth-flow", address=url)
+
+    assert result["addressed"]["comment_id"] == "999"
+    assert result["addressed"]["recorded"] is True
+
+
+def test_commit_with_address_rejects_unknown_id(workspace_with_feature):
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},
+    })
+    _set_remote(workspace_with_feature / "repo-a", "git@github.com:owner/repo-a.git")
+    ws = _make_workspace(workspace_with_feature, repos=("repo-a",))
+
+    with patch("canopy.actions.feature_state.gh.find_pull_request",
+               return_value=_open_pr()), \
+         patch("canopy.actions.feature_state.gh.get_review_comments",
+               return_value=([_bot_comment(1)], 0)):
+        with pytest.raises(BlockerError) as exc:
+            commit(ws, "fix", feature="auth-flow", address="999999")
+    assert exc.value.code == "not_a_bot_comment"
+
+
+def test_commit_with_address_uses_only_auto_message_when_no_message(
+    workspace_with_feature,
+):
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},
+    })
+    _set_remote(workspace_with_feature / "repo-a", "git@github.com:owner/repo-a.git")
+    ws = _make_workspace(workspace_with_feature, repos=("repo-a",))
+
+    (workspace_with_feature / "repo-a" / "src" / "app.py").write_text("changed\n")
+
+    with patch("canopy.actions.feature_state.gh.find_pull_request",
+               return_value=_open_pr()), \
+         patch("canopy.actions.feature_state.gh.get_review_comments",
+               return_value=([_bot_comment(123, body="please rename hit_rate")], 0)):
+        result = commit(ws, "", feature="auth-flow", address="123")
+
+    sha = result["results"]["repo-a"]["sha"]
+    msg = subprocess.run(
+        ["git", "log", "-1", "--format=%B", sha],
+        cwd=workspace_with_feature / "repo-a",
+        check=True, capture_output=True, text=True,
+    ).stdout
+    assert msg.strip().startswith('Addresses bot comment: "please rename hit_rate"')

--- a/tests/test_feature_state_bot.py
+++ b/tests/test_feature_state_bot.py
@@ -1,0 +1,209 @@
+"""M3 tests for feature_state — bot vs human comment classification + new state."""
+from __future__ import annotations
+
+import json
+import os
+import subprocess
+from unittest.mock import patch
+
+from canopy.actions.bot_resolutions import record_resolution
+from canopy.actions.feature_state import feature_state, _is_bot_comment
+from canopy.workspace.config import RepoConfig, WorkspaceConfig
+from canopy.workspace.workspace import Workspace
+
+
+def _make_workspace(workspace_dir, *, augments=None):
+    config = WorkspaceConfig(
+        name="test",
+        repos=[RepoConfig(name="repo-a", path="./repo-a", role="x", lang="x")],
+        root=workspace_dir,
+        augments=augments or {},
+    )
+    return Workspace(config)
+
+
+def _features_file(workspace_dir, payload):
+    canopy_dir = workspace_dir / ".canopy"
+    canopy_dir.mkdir(exist_ok=True)
+    (canopy_dir / "features.json").write_text(json.dumps(payload))
+
+
+def _set_remote(repo_path, url):
+    subprocess.run(
+        ["git", "remote", "add", "origin", url],
+        cwd=repo_path, check=True, capture_output=True, text=True,
+    )
+
+
+def _bot_comment(comment_id, *, author="coderabbit", body="please rename foo"):
+    return {
+        "id": comment_id, "path": "src/auth.py", "line": 1, "body": body,
+        "author": author, "author_type": "Bot", "state": "",
+        "created_at": "2030-01-01T00:00:00Z", "url": f"https://gh/c/{comment_id}",
+        "in_reply_to_id": None,
+    }
+
+
+def _human_comment(comment_id, *, author="reviewer", body="this needs work"):
+    return {
+        "id": comment_id, "path": "src/auth.py", "line": 1, "body": body,
+        "author": author, "author_type": "User", "state": "",
+        "created_at": "2030-01-01T00:00:00Z", "url": f"https://gh/c/{comment_id}",
+        "in_reply_to_id": None,
+    }
+
+
+def _open_pr(review_decision="REVIEW_REQUIRED"):
+    return {"number": 1, "title": "x", "url": "u", "state": "open",
+            "head_branch": "auth-flow", "base_branch": "main", "body": "",
+            "review_decision": review_decision, "mergeable": "", "draft": False}
+
+
+# ── _is_bot_comment ──────────────────────────────────────────────────────
+
+
+def test_is_bot_comment_true_when_typed_bot_no_subs_configured():
+    assert _is_bot_comment({"author_type": "Bot", "author": "any"}, []) is True
+
+
+def test_is_bot_comment_false_when_user_no_subs_configured():
+    assert _is_bot_comment({"author_type": "User", "author": "alice"}, []) is False
+
+
+def test_is_bot_comment_requires_substring_match_when_subs_configured():
+    bots = ["coderabbit", "korbit"]
+    assert _is_bot_comment({"author_type": "Bot", "author": "coderabbit-bot"}, bots) is True
+    assert _is_bot_comment({"author_type": "Bot", "author": "korbit"}, bots) is True
+    # Typed Bot, but not in the configured list — drops out.
+    assert _is_bot_comment({"author_type": "Bot", "author": "copilot"}, bots) is False
+    # Substring match but not typed Bot — drops out.
+    assert _is_bot_comment({"author_type": "User", "author": "coderabbit-fan"}, bots) is False
+
+
+# ── awaiting_bot_resolution state ────────────────────────────────────────
+
+
+def test_awaiting_bot_resolution_when_only_bot_comments(workspace_with_feature):
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},
+    })
+    _set_remote(workspace_with_feature / "repo-a", "git@github.com:owner/repo-a.git")
+    ws = _make_workspace(workspace_with_feature)
+
+    with patch("canopy.actions.feature_state.gh.find_pull_request",
+               return_value=_open_pr()), \
+         patch("canopy.actions.feature_state.gh.get_review_comments",
+               return_value=([_bot_comment(101)], 0)):
+        result = feature_state(ws, "auth-flow")
+
+    assert result["state"] == "awaiting_bot_resolution"
+    assert result["next_actions"][0]["action"] == "address_bot_comments"
+    assert result["summary"]["actionable_bot_count"] == 1
+    assert result["summary"]["actionable_human_count"] == 0
+
+
+def test_human_comment_routes_to_needs_work_not_bot_state(workspace_with_feature):
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},
+    })
+    _set_remote(workspace_with_feature / "repo-a", "git@github.com:owner/repo-a.git")
+    ws = _make_workspace(workspace_with_feature)
+
+    with patch("canopy.actions.feature_state.gh.find_pull_request",
+               return_value=_open_pr()), \
+         patch("canopy.actions.feature_state.gh.get_review_comments",
+               return_value=([_human_comment(202)], 0)):
+        result = feature_state(ws, "auth-flow")
+
+    assert result["state"] == "needs_work"
+    assert result["summary"]["actionable_human_count"] == 1
+    assert result["summary"]["actionable_bot_count"] == 0
+
+
+def test_mixed_human_and_bot_routes_to_needs_work(workspace_with_feature):
+    """Human signal wins; bot count is included in the preview."""
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},
+    })
+    _set_remote(workspace_with_feature / "repo-a", "git@github.com:owner/repo-a.git")
+    ws = _make_workspace(workspace_with_feature)
+
+    with patch("canopy.actions.feature_state.gh.find_pull_request",
+               return_value=_open_pr()), \
+         patch("canopy.actions.feature_state.gh.get_review_comments",
+               return_value=([_human_comment(1), _bot_comment(2)], 0)):
+        result = feature_state(ws, "auth-flow")
+
+    assert result["state"] == "needs_work"
+    assert result["summary"]["actionable_human_count"] == 1
+    assert result["summary"]["actionable_bot_count"] == 1
+
+
+def test_approved_with_bot_threads_keeps_state_but_adds_secondary_cta(
+    workspace_with_feature,
+):
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},
+    })
+    _set_remote(workspace_with_feature / "repo-a", "git@github.com:owner/repo-a.git")
+    ws = _make_workspace(workspace_with_feature)
+
+    with patch("canopy.actions.feature_state.gh.find_pull_request",
+               return_value=_open_pr(review_decision="APPROVED")), \
+         patch("canopy.actions.feature_state.gh.get_review_comments",
+               return_value=([_bot_comment(303)], 0)):
+        result = feature_state(ws, "auth-flow")
+
+    assert result["state"] == "approved"
+    actions = result["next_actions"]
+    assert actions[0]["action"] == "merge"
+    # Secondary CTA appears for the unresolved bot thread.
+    assert any(a["action"] == "address_bot_comments" for a in actions)
+
+
+def test_recorded_resolution_is_subtracted_from_bot_count(workspace_with_feature):
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},
+    })
+    _set_remote(workspace_with_feature / "repo-a", "git@github.com:owner/repo-a.git")
+    ws = _make_workspace(workspace_with_feature)
+
+    # Pre-record a resolution for comment 999 against this feature.
+    record_resolution(
+        workspace_with_feature, comment_id=999, feature="auth-flow",
+        repo="repo-a", commit_sha="deadbeef", comment_title="resolved one",
+    )
+
+    # Live PR still surfaces both comments — but 999 is filtered out.
+    with patch("canopy.actions.feature_state.gh.find_pull_request",
+               return_value=_open_pr()), \
+         patch("canopy.actions.feature_state.gh.get_review_comments",
+               return_value=([_bot_comment(999), _bot_comment(1000)], 0)):
+        result = feature_state(ws, "auth-flow")
+
+    assert result["summary"]["actionable_bot_count"] == 1
+    assert result["state"] == "awaiting_bot_resolution"
+
+
+def test_review_bots_augment_narrows_classification(workspace_with_feature):
+    """When review_bots is configured, only matching authors count as bots."""
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},
+    })
+    _set_remote(workspace_with_feature / "repo-a", "git@github.com:owner/repo-a.git")
+    ws = _make_workspace(
+        workspace_with_feature, augments={"review_bots": ["coderabbit"]},
+    )
+
+    with patch("canopy.actions.feature_state.gh.find_pull_request",
+               return_value=_open_pr()), \
+         patch("canopy.actions.feature_state.gh.get_review_comments",
+               return_value=([
+                   _bot_comment(1, author="coderabbit"),
+                   _bot_comment(2, author="copilot"),  # filtered out by augment
+               ], 0)):
+        result = feature_state(ws, "auth-flow")
+
+    assert result["summary"]["actionable_bot_count"] == 1
+    # The non-matching bot author falls into human bucket — augment is the gate.
+    assert result["summary"]["actionable_human_count"] == 1


### PR DESCRIPTION
## Summary

Treats bot review comments (CodeRabbit, Korbit, Cubic, etc.) as a distinct workflow concern with structured persistence + a focused command. Adds a new state-machine state, splits actionable comment counts into bot vs human, and gives `canopy commit --address <comment-id>` semantics.

Closes the M3 milestone in [docs/plans/bot-tracking.md](https://github.com/ashmitb95/canopy/blob/feat/m3-bot-tracking/docs/plans/bot-tracking.md). Frontmatter still says `in-progress`; flip to `shipped` + archive on merge (matches the M5 / M2 cadence).

## What changed

### Data model
- `integrations/github.py:_normalize_comments` now includes the GitHub `id` field on each comment (back-compat — consumers ignoring it still work).
- New persistent state at `<workspace>/.canopy/state/bot_resolutions.json` mapping `comment_id → {feature, repo, commit_sha, addressed_at, comment_title, comment_url}`. Atomic writes via temp file + `os.replace`.

### Resolver + state machine
- `actions/feature_state.py:_per_repo_facts` splits `actionable_count` into `actionable_human_count` + `actionable_bot_count` (legacy total preserved). Bot vs human classification uses the M2 `bot_authors()` augment when configured, falls back to GitHub's `author_type == "Bot"` otherwise. Resolved comments are subtracted from the bot count.
- New state **`awaiting_bot_resolution`** between `awaiting_review` and `approved`. Trigger: clean + PR open + no human signal + ≥1 unresolved bot thread + not yet APPROVED. Bot nits never gate `approved` — when approved with bot threads still open, state stays `approved` and "address bot comments" surfaces as a secondary CTA.

### Surface
- `actions/commit.py` gains `address: str | None = None`. Accepts numeric ids or GitHub URLs (parses trailing digits), looks up the comment in the feature's actionable bot threads, auto-formats the message with `Addresses bot comment: "<title>" (<url>)`, records the resolution against the matching repo's sha. Non-bot comments raise `BlockerError(code='not_a_bot_comment')`.
- New `actions/bot_status.py` + `canopy bot-status` CLI + `bot_comments_status` MCP tool: per-feature rollup with total / resolved / unresolved per repo + `all_resolved` flag.

## Tests

- `test_bot_resolutions.py` (new, 10): record/load round-trip, atomic write, idempotent overwrite, str/int id normalization.
- `test_bot_status.py` (new, 5): empty rollup, all-unresolved, mixed resolved+unresolved, all-resolved, blocker on no-canonical.
- `test_feature_state_bot.py` (new, 10): `_is_bot_comment` semantics, `awaiting_bot_resolution` triggers, mixed human+bot routes to `needs_work`, approved + bot threads keeps state but adds secondary CTA, recorded resolutions subtract from count, `review_bots` augment narrows classification.
- `test_commit.py` (+11): `--address` integration tests + helper unit tests (`_parse_comment_id`, `_format_address_message`, `_comment_title`).

Suite: 566 → 602 passing.

## Docs

- `concepts.md`: 8-state → 9-state machine table + state-transition diagram updated; added bot/human classification note.
- `commands.md`, `mcp.md`, `agents.md`, `CLAUDE.md`: `bot-status` + `commit --address` surface.
- `using-canopy/SKILL.md`: new "Bot review comments" section teaching when to call `bot_comments_status` / `commit --address` and the "one comment per commit" guidance.

## Test plan

- [x] `python -m pytest tests/test_bot_resolutions.py tests/test_bot_status.py tests/test_feature_state_bot.py tests/test_commit.py -q` (48 pass)
- [x] Full suite: `python -m pytest -q` (602 pass)
- [ ] Manual: real PR with a CodeRabbit comment → `canopy bot-status` shows it → `canopy commit --address <id> -m "fix"` produces a properly-attributed commit → next `bot-status` shows it resolved → `feature_state` returns `awaiting_review` (or `approved`) instead of `awaiting_bot_resolution`.

## After merge

- Flip `docs/plans/bot-tracking.md` frontmatter `status: in-progress` → `shipped`.
- `git mv docs/plans/bot-tracking.md docs/plans/archive/bot-tracking.md`.
- Update `docs/plans/INDEX.md` — move M3 to "Shipped" with date; bump effort summary (Core M3-M4 → M4 only).

## Unblocks

- **M4 (Historian)** — consumes `bot_resolutions.json` + `commit --address` flow as data sources for the per-feature memory file's "Resolutions log" section.
- **M11 (Action drawer)** — the dashboard's "Address bot comments" CTA is now wirable: state machine surfaces it; quick-pick can read `bot_comments_status.repos[].threads`.