### PR TITLE
chore(plans): flip M3 to shipped + archive bot-tracking.md

### DIFF
--- a/docs/plans/INDEX.md
+++ b/docs/plans/INDEX.md
@@ -2,7 +2,7 @@
 
 Live status of canopy's planned work. Update this file as milestones progress; each plan's frontmatter is the per-plan source of truth, this doc is the rolled-up dashboard.
 
-**Last updated:** 2026-05-02 (M0, M1, M2, M5 shipped; M3 in-progress)
+**Last updated:** 2026-05-02 (M0, M1, M2, M3, M5 shipped)
 **Roadmap:** [roadmap.md](roadmap.md) — full architecture context, cross-cutting decisions, sequencing rationale
 
 ## Status legend
@@ -26,8 +26,8 @@ Live status of canopy's planned work. Update this file as milestones progress; e
 
 - [x] ✅ **M2 — Augment skill** — [archive/augments.md](archive/augments.md) · shipped 2026-05-02
   Per-workspace `[augments]` block in canopy.toml + opt-in `augment-canopy` skill. Wires `preflight_cmd`; reserves `review_bots` (M3) and `test_cmd` (future).
-- [ ] 🟨 **M3 — Bot-comment tracking** — [bot-tracking.md](bot-tracking.md) · P1 · ~3d · depends on M2
-  Distinguish bot vs human review comments, `commit --address <id>`, new `awaiting_bot_resolution` state.
+- [x] ✅ **M3 — Bot-comment tracking** — [archive/bot-tracking.md](archive/bot-tracking.md) · shipped 2026-05-02
+  Bot vs human comment classification, `commit --address <id>`, `awaiting_bot_resolution` state, `bot-status` rollup.
 - [ ] 🟦 **M4 — Historian** — [historian.md](historian.md) · P1 · ~5-6d · depends on M3
   Cross-session feature memory at `.canopy/memory/<feature>.md`. Auto-read on `canopy switch`.
 - [x] ✅ **M5 — Issue-provider scaffold** — [archive/issue-providers.md](archive/issue-providers.md) · shipped 2026-04-27
@@ -45,6 +45,7 @@ Live status of canopy's planned work. Update this file as milestones progress; e
 
 ### Shipped
 
+- [x] ✅ **M3 — Bot-comment tracking** — [archive/bot-tracking.md](archive/bot-tracking.md) · shipped 2026-05-02 (PR #12)
 - [x] ✅ **M2 — Augment skill** — [archive/augments.md](archive/augments.md) · shipped 2026-05-02 (PR #10)
 - [x] ✅ **M5 — Issue-provider scaffold** — [archive/issue-providers.md](archive/issue-providers.md) · shipped 2026-04-27
 - [x] ✅ **M1 — `canopy doctor`** — [archive/doctor.md](archive/doctor.md) · shipped 2026-05-02
@@ -57,9 +58,9 @@ Live status of canopy's planned work. Update this file as milestones progress; e
 
 | Bucket | Milestones | Estimate |
 |---|---|---|
-| Core (M3–M4) | 2 | ~8–9 days |
+| Core (M4) | 1 | ~5–6 days |
 | Quality-of-life (M6–M12) | 7 | ~13–18 days |
-| **Total queued** | **9** | **~21–27 days** |
+| **Total queued** | **8** | **~18–24 days** |
 
 ---
 

--- a/docs/plans/archive/bot-tracking.md
+++ b/docs/plans/archive/bot-tracking.md
@@ -1,8 +1,9 @@
 ---
-status: in-progress
+status: shipped
 priority: P1
 effort: ~3d
 depends_on: ["augments.md"]
+shipped: 2026-05-02
 ---
 
 # Bot-comment tracking + `commit --address`


### PR DESCRIPTION
## Summary

Post-merge tracker admin for [PR #12](https://github.com/ashmitb95/canopy/pull/12) (M3 bot-tracking). Mirrors the [PR #11](https://github.com/ashmitb95/canopy/pull/11) cadence we used after M2.

## Changes

- `docs/plans/bot-tracking.md` → `docs/plans/archive/bot-tracking.md` (git rename preserves history)
- Frontmatter: `status: in-progress` → `status: shipped`, add `shipped: 2026-05-02`
- `docs/plans/INDEX.md`: M3 moves to "Shipped"; effort summary now Core (M4) = 1, total queued 9 → 8