### PR TITLE
fix(cli): F-1, F-6, F-9 from test-findings.md (CLI UX cleanup)

### DIFF
--- a/docs/test-findings.md
+++ b/docs/test-findings.md
@@ -41,13 +41,11 @@ Running any workspace-scoped command (e.g. `canopy setup-agent --check`, `canopy
 - **Severity:** low individually; medium for new-user friction (this is the first error a fresh install hits).
 - **Fix:** centralize the "no canopy.toml" error rendering in one place (`cli/render.py` or a small helper in `cli/main.py`) so every command that depends on a workspace prints the same, helpful message — and exits non-zero (see F-2).
 
-### F-2: error path returns exit code 0
+### F-2: error path returns exit code 0 ~~(INVALID — measurement error)~~
 
-When `setup-agent --check` fails because no canopy.toml exists, `echo $?` is `0`. Should be non-zero so shell scripts catch it.
+**Retracted.** Re-verified after the test run: `canopy setup-agent --check` exits 1, and `canopy issue <unresolvable> --json` (BlockerError JSON output) also exits 1. My original `echo $?` was capturing a later step in the bash chain, not the canopy command. Exit codes are already correct.
 
-- **Repro:** `canopy setup-agent --check; echo $?` outside a workspace → `Error:` printed, `0` exit.
-- **Severity:** medium — breaks shell-script integration; CI scripts that wrap canopy will silently miss errors.
-- **Fix:** all error-print branches in `cli/main.py` should `sys.exit(1)` after printing.
+Lesson for future test runs: capture exit codes inline (`canopy ... ; EC=$?`), not after intervening commands.
 
 ### F-3: stale `canopy-mcp` processes accumulate
 
@@ -97,12 +95,9 @@ This is a **major M5 integration gap**: M5 added the Provider Protocol + registr
 - **Fix:** rewrite `resolve_linear_id` (rename to `resolve_issue_id`) to consult the active provider for what shapes it accepts. GitHub Issues: bare number, `#N`, `owner/repo#N`, full URL. Linear: `<TEAM>-<N>`, feature names. Provider can expose a `parse_alias(s) -> str | None` method (returns canonical id if accepted, else None); resolver tries provider first, falls back to feature-name lookup.
 - **Adjacent:** Phil's branch has `actions/issue_resolver.py` with auto-detect logic (`SIN-N` → Linear, `owner/repo#N` → GitHub, etc.) — could be ported when his PR rebases onto M5.
 
-### F-2 generalized: BlockerError JSON output → exit 0
+### F-2 generalized ~~(INVALID — same measurement error as F-2)~~
 
-Same root cause as F-2 but worth re-stating: when `canopy issue 5` returns a BlockerError as JSON, the exit code is still 0. Any shell script wrapping `canopy issue` and checking `$?` will silently miss the failure. This applies to all CLI commands that emit BlockerError JSON.
-
-- **Severity:** medium — script integration footgun.
-- **Fix:** in `cli/main.py`, every code path that prints BlockerError JSON should `sys.exit(1)` after.
+Retracted along with F-2. Verified `canopy issue 999 --json` exits 1 on BlockerError output.
 
 ### F-9: `setup-agent --check` only reports the default skill
 
@@ -139,7 +134,7 @@ This is the recovery scenario M1 was built for. Detection works end-to-end again
 
 - [ ] **F-7 fix (P0)** — make alias resolver provider-aware. The CLI for any non-Linear provider is currently dead. ~half-day. Could compose with Phil's `issue_resolver.py` if his PR lands first.
 - [ ] **F-6 fix (P1)** — make `cmd_issue` render `Issue.to_dict()` directly so CLI + MCP agree. Drop the legacy raw-state shape. Update docs/commands.md. ~30 min.
-- [ ] **F-1 + F-2 + F-2-generalized fix (P1)** — centralize the "no canopy.toml" error in one helper that prints the workspace-explainer message and exits non-zero. Apply to every workspace-scoped command. Plus: every CLI path that emits a BlockerError JSON should `sys.exit(1)`. ~30 min.
+- [ ] **F-1 fix (P1)** — improve the "no canopy.toml" error message to explain canopy's mental model (workspace = non-git directory holding repos + canopy.toml). ~10 min.
 - [ ] **F-5 fix (P2)** — add `cmd_issues` for parity with the MCP `issue_list_my_issues`, OR defer to Phil's PR (which has it).
 - [ ] **F-3 backlog** — doctor `mcp_orphans` check + reaper.
 - [ ] **F-4 backlog** — Linear-headless smoke test using cached tokens; document the OAuth-required-in-tty constraint in docs/mcp.md.

--- a/src/canopy/actions/reads.py
+++ b/src/canopy/actions/reads.py
@@ -23,8 +23,55 @@ from .aliases import (
 from .errors import BlockerError, FixAction
 
 
+def issue_get(workspace: Workspace, alias: str) -> dict:
+    """Fetch an issue and return the canonical ``Issue.to_dict()`` shape.
+
+    Mirrors ``mcp__canopy__issue_get``. Canonical fields: ``id``,
+    ``identifier``, ``title``, ``description``, ``state`` (mapped to
+    ``todo`` / ``in_progress`` / ``done`` / ``cancelled``), ``url``,
+    ``assignee``, ``labels``, ``priority``, ``raw``.
+
+    Use this from new CLI / action code. ``linear_get_issue`` (below)
+    is the legacy wrapper that exposes the raw provider state for
+    pre-M5 callers — kept until they migrate.
+    """
+    issue_id = resolve_linear_id(workspace, alias)
+    provider = get_issue_provider(workspace)
+    try:
+        issue = provider.get_issue(issue_id)
+    except ProviderNotConfigured as e:
+        raise BlockerError(
+            code="issue_provider_not_configured",
+            what=f"Issue provider '{workspace.config.issue_provider.name}' is not configured",
+            details={"alias": alias, "issue_id": issue_id, "error": str(e)},
+            fix_actions=[
+                FixAction(
+                    action="configure_provider",
+                    args={"provider": workspace.config.issue_provider.name},
+                    safe=True,
+                    preview=f"configure {workspace.config.issue_provider.name} per docs/architecture/providers.md §4",
+                ),
+            ],
+        )
+    except IssueNotFoundError as e:
+        raise BlockerError(
+            code="issue_not_found",
+            what=f"Issue '{issue_id}' not found",
+            details={"alias": alias, "issue_id": issue_id, "error": str(e)},
+        )
+    out = issue.to_dict()
+    out["alias"] = alias   # convenience — original alias the caller passed
+    return out
+
+
 def linear_get_issue(workspace: Workspace, alias: str) -> dict:
-    """Fetch an issue from the workspace's configured issue provider.
+    """**Deprecated.** Legacy wrapper that exposes raw provider state.
+
+    Pre-M5 callers used this and asserted on ``state`` carrying the raw
+    string ("Todo", "open"). New code should call ``issue_get`` instead,
+    which returns the canonical mapped ``Issue.to_dict()`` shape.
+
+    Kept until: deprecated MCP tool ``linear_get_issue`` is retired.
 
     Despite the historical name, after M5 this resolves through the
     provider registry — the workspace's ``[issue_provider]`` block picks

--- a/src/canopy/agent_setup/__init__.py
+++ b/src/canopy/agent_setup/__init__.py
@@ -164,11 +164,17 @@ def install_mcp(workspace_root: Path, *, reinstall: bool = False) -> McpResult:
 def check_status(workspace_root: Path) -> dict:
     """Report what's installed without changing anything.
 
-    The skill-state report covers the default ``using-canopy`` skill for
-    backward compatibility. Use ``check_skill_status(name)`` for any
-    bundled skill.
+    Returns ``{skill, skills, mcp}``:
+
+    - ``skill`` — the default ``using-canopy`` entry (kept for
+      backward-compat with existing callers / dashboard).
+    - ``skills`` — every bundled skill's install state, including
+      opt-ins like ``augment-canopy`` once they're installed (M4
+      revealed that ``--check`` only reported the default; F-9).
+    - ``mcp`` — the workspace's ``.mcp.json`` canopy entry state.
     """
     skill_state = check_skill_status(DEFAULT_SKILL)
+    skills_state = [check_skill_status(name) for name in available_skills()]
 
     mcp_target = mcp_config_path(workspace_root)
     mcp_state = {"path": str(mcp_target), "configured": False}
@@ -184,7 +190,7 @@ def check_status(workspace_root: Path) -> dict:
         except json.JSONDecodeError:
             mcp_state["error"] = "invalid JSON"
 
-    return {"skill": skill_state, "mcp": mcp_state}
+    return {"skill": skill_state, "skills": skills_state, "mcp": mcp_state}
 
 
 def check_skill_status(name: str) -> dict:

--- a/src/canopy/cli/main.py
+++ b/src/canopy/cli/main.py
@@ -50,12 +50,37 @@ def _load_workspace():
 
     try:
         config = load_config()
-    except ConfigNotFoundError as e:
-        print(f"Error: {e}", file=sys.stderr)
-        print("Run `canopy init` to create a canopy.toml.", file=sys.stderr)
+    except ConfigNotFoundError:
+        _print_no_workspace_error()
         sys.exit(1)
 
     return Workspace(config)
+
+
+def _print_no_workspace_error() -> None:
+    """Render the canonical 'no canopy.toml' error.
+
+    Centralised so every workspace-scoped command prints the same helpful
+    message instead of a terse "No canopy.toml found." See test-findings
+    F-1: this is the first error a fresh user is likely to hit.
+    """
+    print("Error: no canopy.toml found here or in any parent directory.",
+          file=sys.stderr)
+    print(file=sys.stderr)
+    print(
+        "Canopy needs to be run from a workspace — a non-git directory that holds",
+        file=sys.stderr,
+    )
+    print(
+        "your repos as subdirectories along with canopy.toml. Either:",
+        file=sys.stderr,
+    )
+    print(file=sys.stderr)
+    print("  • cd into your existing workspace root, or", file=sys.stderr)
+    print(
+        "  • run `canopy init` from a non-git directory containing the repos to bootstrap one.",
+        file=sys.stderr,
+    )
 
 
 # ── Commands ──────────────────────────────────────────────────────────────
@@ -1700,20 +1725,34 @@ def _read_command(impl, args, action_label: str, *extra_kwargs_keys):
 
 
 def cmd_issue(args: argparse.Namespace) -> None:
-    """Fetch a Linear issue by alias."""
-    from ..actions.reads import linear_get_issue
+    """Fetch an issue from the workspace's configured provider.
+
+    Uses the M5 ``issue_get`` action so the CLI surface matches the
+    ``mcp__canopy__issue_get`` MCP tool — canonical state mapping
+    (``todo`` / ``in_progress`` / ``done`` / ``cancelled``) and the
+    full ``Issue`` shape (id, identifier, title, description, state,
+    url, assignee, labels, priority, raw).
+    """
+    from ..actions.reads import issue_get
     from .ui import console
 
-    result = _read_command(linear_get_issue, args, "issue")
+    result = _read_command(issue_get, args, "issue")
     if args.json:
         _print_json(result)
         return
     console.print()
-    console.print(f"  [feature]{result['issue_id']}[/]  [muted]{result.get('state','')}[/]")
+    identifier = result.get("identifier") or result.get("id") or ""
+    state = result.get("state") or ""
+    console.print(f"  [feature]{identifier}[/]  [muted]{state}[/]")
     if result.get("title"):
         console.print(f"  {result['title']}")
     if result.get("url"):
         console.print(f"  [muted]{result['url']}[/]")
+    if result.get("assignee"):
+        console.print(f"  [muted]assignee:[/] {result['assignee']}")
+    labels = result.get("labels") or []
+    if labels:
+        console.print(f"  [muted]labels:[/] {', '.join(labels)}")
     if result.get("description"):
         desc = result["description"].strip()
         if len(desc) > 400:
@@ -1832,16 +1871,18 @@ def cmd_setup_agent(args: argparse.Namespace) -> None:
         if args.json:
             _print_json(status)
             return
-        skill = status["skill"]
+        skills_state = status.get("skills") or [status["skill"]]
         mcp = status["mcp"]
         console.print()
-        if skill["installed"] and skill["is_canopy_skill"]:
-            label = "[success]✓ up to date[/]" if skill["up_to_date"] else "[warning]● out of date[/]"
-            console.print(f"  skill   {label}  [muted]{skill['path']}[/]")
-        elif skill["installed"]:
-            console.print(f"  skill   [warning]foreign file present[/]  [muted]{skill['path']}[/]")
-        else:
-            console.print(f"  skill   [error]✗ not installed[/]  [muted]{skill['path']}[/]")
+        for skill in skills_state:
+            label_name = skill.get("name", "")
+            if skill["installed"] and skill["is_canopy_skill"]:
+                label = "[success]✓ up to date[/]" if skill["up_to_date"] else "[warning]● out of date[/]"
+                console.print(f"  skill[{label_name}]  {label}  [muted]{skill['path']}[/]")
+            elif skill["installed"]:
+                console.print(f"  skill[{label_name}]  [warning]foreign file present[/]  [muted]{skill['path']}[/]")
+            else:
+                console.print(f"  skill[{label_name}]  [muted]not installed[/]  [muted]{skill['path']}[/]")
         if mcp["configured"]:
             root = (mcp.get("env") or {}).get("CANOPY_ROOT", "")
             console.print(f"  mcp     [success]✓ configured[/]  [muted]CANOPY_ROOT={root}[/]")

--- a/tests/test_agent_setup.py
+++ b/tests/test_agent_setup.py
@@ -149,6 +149,36 @@ def test_check_status_after_install(fake_home, tmp_path):
     assert status["mcp"]["configured"] is True
 
 
+def test_check_status_reports_all_installed_skills(fake_home, tmp_path):
+    """F-9: --check should iterate every bundled skill, not just the default."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    install_skill("using-canopy")
+    install_skill("augment-canopy")
+    status = check_status(workspace)
+    skills = status.get("skills") or []
+    by_name = {s["name"]: s for s in skills}
+    # Both bundled skills appear in the report
+    assert "using-canopy" in by_name
+    assert "augment-canopy" in by_name
+    assert by_name["using-canopy"]["installed"] is True
+    assert by_name["augment-canopy"]["installed"] is True
+    # Back-compat: top-level "skill" still mirrors the default (using-canopy)
+    assert status["skill"]["name"] == "using-canopy"
+
+
+def test_check_status_lists_uninstalled_skills_too(fake_home, tmp_path):
+    """skills array shows installed=false for opt-in skills not yet copied."""
+    workspace = tmp_path / "ws"
+    workspace.mkdir()
+    install_skill("using-canopy")
+    # Don't install augment-canopy
+    status = check_status(workspace)
+    by_name = {s["name"]: s for s in (status.get("skills") or [])}
+    assert by_name["using-canopy"]["installed"] is True
+    assert by_name["augment-canopy"]["installed"] is False
+
+
 # ── setup_agent (composite) ──────────────────────────────────────────────
 
 def test_setup_agent_does_both_by_default(fake_home, tmp_path):

--- a/tests/test_reads.py
+++ b/tests/test_reads.py
@@ -105,6 +105,49 @@ def test_linear_get_issue_no_linear_link_raises(workspace_with_feature):
     assert exc_info.value.code == "no_linear_id"
 
 
+# ── issue_get (M5+, canonical Issue shape — F-6 fix) ─────────────────────
+
+
+def test_issue_get_returns_canonical_shape(workspace_with_feature):
+    """F-6: new CLI/action surface returns Issue.to_dict() directly,
+    with canonical state mapping ('todo'/'in_progress'/'done'/'cancelled')
+    rather than raw provider strings."""
+    from canopy.actions.reads import issue_get
+    from canopy.providers.types import Issue
+    ws = _make_workspace(workspace_with_feature)
+    fake = Issue(
+        id="SIN-412", identifier="SIN-412", title="Test",
+        description="d", state="in_progress",
+        url="https://linear.app/x/issue/SIN-412",
+        assignee="alice",
+        labels=("bug", "p1"),
+        raw={"state": {"name": "Active"}},   # raw "Active", canonical "in_progress"
+    )
+    with patch("canopy.actions.reads.get_issue_provider", return_value=_fake_provider(fake)):
+        result = issue_get(ws, "SIN-412")
+    # Canonical fields
+    assert result["identifier"] == "SIN-412"
+    assert result["state"] == "in_progress"   # NOT "Active"
+    assert result["title"] == "Test"
+    assert result["assignee"] == "alice"
+    assert result["labels"] == ["bug", "p1"]   # to_dict converts tuple → list
+    # Convenience field
+    assert result["alias"] == "SIN-412"
+
+
+def test_issue_get_propagates_provider_not_configured(workspace_with_feature):
+    from canopy.actions.reads import issue_get
+    from canopy.providers.types import ProviderNotConfigured
+    from unittest.mock import MagicMock
+    ws = _make_workspace(workspace_with_feature)
+    provider = MagicMock()
+    provider.get_issue.side_effect = ProviderNotConfigured("nope")
+    with patch("canopy.actions.reads.get_issue_provider", return_value=provider):
+        with pytest.raises(BlockerError) as exc_info:
+            issue_get(ws, "SIN-412")
+    assert exc_info.value.code == "issue_provider_not_configured"
+
+
 # ── github_get_pr ────────────────────────────────────────────────────────
 
 def test_github_get_pr_specific_form(workspace_with_feature):


### PR DESCRIPTION
## Summary

Three small CLI bugs surfaced by the first manual integration run ([docs/test-findings.md](https://github.com/ashmitb95/canopy/blob/main/docs/test-findings.md)).

## Fixes

### F-1 — improve "no canopy.toml" error
The terse `"No canopy.toml found in current directory or any parent"` doesn't tell new users *what* canopy needs. Now a centralised helper (`_print_no_workspace_error`) explains the workspace mental model:

```
Error: no canopy.toml found here or in any parent directory.

Canopy needs to be run from a workspace — a non-git directory that holds
your repos as subdirectories along with canopy.toml. Either:

  • cd into your existing workspace root, or
  • run `canopy init` from a non-git directory containing the repos to bootstrap one.
```

Exit code stays 1.

### F-6 — `canopy issue` returns canonical Issue shape
**Before:** CLI returned `{alias, issue_id, title, state: "Todo", url, description, raw}` — raw provider state, missing fields.
**After:** CLI returns `{id, identifier, title, description, state: "todo", url, assignee, labels, priority, raw, alias}` — same shape as `mcp__canopy__issue_get`.

New `actions/reads.py:issue_get` returns `Issue.to_dict()` directly. `linear_get_issue` kept as a deprecated wrapper for the still-aliased MCP tool.

### F-9 — `setup-agent --check` reports every installed skill
**Before:** only `using-canopy` reported, even when `augment-canopy` was installed.
**After:** `check_status` returns a `skills` array via `available_skills()`; CLI rendering iterates it. Legacy `skill` field stays for back-compat.

```
$ canopy setup-agent --check --json | jq '.skills'
[
  {"name": "augment-canopy", "installed": true, "up_to_date": true, ...},
  {"name": "using-canopy",   "installed": true, "up_to_date": true, ...}
]
```

## Also retracts F-2 + F-2-generalized

The "exit 0 on error" claims in the original test-findings were a measurement bug — `echo \$?` captured a later command in the bash chain. Re-verified: every error path already exits non-zero correctly. Marked invalid in test-findings.md.

## Tests

+4 new (test_agent_setup: 2 for F-9, test_reads: 2 for F-6). Suite: 624 → 628 passing.

## Test plan

- [x] `python -m pytest -q` (628 pass)
- [x] Manual: `cd / && canopy state` shows the new helpful error, exits 1.
- [x] Manual: `cd canopy-test && canopy issue SIN-5 --json` returns canonical shape (state: "todo", includes assignee/labels/priority).
- [x] Manual: `cd canopy-test && canopy setup-agent --check --json` returns `skills` array with both skills.

## Remaining from test-findings.md

- F-7 (P0) — provider-aware alias resolver — next PR.
- F-5 (P2) — `canopy issues` plural — bundled with F-7 PR.
- F-3, F-4 — backlog.