### PR TITLE
fix(providers): F-7 + F-10 + F-5 — provider-aware aliases, gh query, canopy issues

### DIFF
--- a/docs/test-findings.md
+++ b/docs/test-findings.md
@@ -99,6 +99,16 @@ This is a **major M5 integration gap**: M5 added the Provider Protocol + registr
 
 Retracted along with F-2. Verified `canopy issue 999 --json` exits 1 on BlockerError output.
 
+### F-10: `gh search issues` query construction is malformed
+
+`GitHubIssuesProvider.list_my_issues` builds a query string with qualifiers (`repo:foo`, `is:open`, `assignee:@me`, `label:"bug"`) and passes it positionally to `gh search issues`. But `gh search issues` treats positional args as search *text*, so the whole string gets quoted and the GitHub API responds with `Invalid search query`.
+
+The unit tests for `list_my_issues` mock `_gh_json` and assert on the constructed args — so they happily passed even though the args were nonsense to the real CLI.
+
+- **Severity:** medium — the entire `canopy issues` / `mcp__canopy__issue_list_my_issues` flow was broken for the GitHub Issues backend on real `gh` invocations.
+- **Fix (this PR):** switch to `gh issue list --repo ... --state open --assignee @me --label ...` (the right verb form). Phil's branch already had this pattern.
+- **Lesson:** mocking at `_gh_json` proves the call wiring but not the CLI grammar. A small live-call smoke test (skipped if `gh` isn't authenticated) would have caught this.
+
 ### F-9: `setup-agent --check` only reports the default skill
 
 `canopy setup-agent --check --json` returns `{skill: {...}, mcp: {...}}` — but `skill` is hardcoded to `using-canopy`. After installing `augment-canopy` via `--skill augment-canopy`, the `--check` output still only reports `using-canopy`'s state.
@@ -132,7 +142,9 @@ This is the recovery scenario M1 was built for. Detection works end-to-end again
 
 ## Action items from this run
 
-- [ ] **F-7 fix (P0)** — make alias resolver provider-aware. The CLI for any non-Linear provider is currently dead. ~half-day. Could compose with Phil's `issue_resolver.py` if his PR lands first.
+- [x] **F-7 fix (P0)** — provider-aware alias resolver via `IssueProvider.parse_alias()`. CLI now works for any provider with bare/hash/owner-repo/URL alias forms. Shipped in fix/issue-alias-resolver PR.
+- [x] **F-10 fix (incidental)** — `GitHubIssuesProvider.list_my_issues` was using malformed `gh search issues` query (qualifiers got quoted as text → `Invalid search query`). Switched to `gh issue list --repo ... --assignee @me`. Found while smoke-testing F-5; unit tests had mocked the boundary so they didn't catch it. Shipped in same PR.
+- [x] **F-5 fix (P2)** — added `cmd_issues` for parity with MCP `issue_list_my_issues`. Shipped in same PR.
 - [ ] **F-6 fix (P1)** — make `cmd_issue` render `Issue.to_dict()` directly so CLI + MCP agree. Drop the legacy raw-state shape. Update docs/commands.md. ~30 min.
 - [ ] **F-1 fix (P1)** — improve the "no canopy.toml" error message to explain canopy's mental model (workspace = non-git directory holding repos + canopy.toml). ~10 min.
 - [ ] **F-5 fix (P2)** — add `cmd_issues` for parity with the MCP `issue_list_my_issues`, OR defer to Phil's PR (which has it).

--- a/src/canopy/actions/aliases.py
+++ b/src/canopy/actions/aliases.py
@@ -144,19 +144,64 @@ def repos_for_feature(
     return out
 
 
-def resolve_linear_id(workspace: Workspace, alias: str) -> str:
-    """Resolve an alias to a Linear issue ID.
+def resolve_issue_id(workspace: Workspace, alias: str) -> str:
+    """Resolve an alias to the active issue provider's canonical id (M5+).
 
-    Accepts:
-      - Linear ID directly (e.g. ``ENG-412``) — returned as-is.
-      - Feature alias — looks up ``linear_issue`` from features.json.
+    Resolution order:
+      1. **Provider parse** — ask the configured provider whether it
+         recognises the alias shape (e.g. ``SIN-412`` for Linear,
+         ``5`` / ``#5`` / ``owner/repo#5`` / GitHub URL for GitHub Issues).
+         If yes, use the provider-canonicalised form.
+      2. **Feature-lane lookup** — treat the alias as a feature name
+         (e.g. ``auth-flow``) and read ``linear_issue`` from
+         features.json. (The field is still named ``linear_issue`` for
+         back-compat; treat it as "linked issue id".)
+      3. **Fail loud** — ``BlockerError(code='no_linked_issue')`` with
+         helpful fix actions.
 
-    Raises ``BlockerError`` if no Linear ID can be derived.
+    Replaces the pre-M5 ``resolve_linear_id`` (kept as a deprecated
+    alias below), which only knew about Linear-shaped IDs and broke the
+    CLI for any other provider — see test-findings F-7.
     """
-    if _LINEAR_ID.match(alias):
-        return alias
+    from ..providers import get_issue_provider, ProviderNotConfigured
 
-    feature_name = resolve_feature(workspace, alias)
+    # Step 1 — provider parse.
+    try:
+        provider = get_issue_provider(workspace)
+    except ProviderNotConfigured:
+        provider = None
+    if provider is not None:
+        try:
+            parsed = provider.parse_alias(alias)
+        except AttributeError:
+            # Older provider that hasn't implemented parse_alias yet —
+            # fall through to feature-lane lookup.
+            parsed = None
+        if parsed:
+            return parsed
+
+    # Step 2 — feature-lane lookup.
+    try:
+        feature_name = resolve_feature(workspace, alias)
+    except BlockerError:
+        # Not a recognised provider shape AND not a feature name.
+        # Re-raise with provider-aware fix-actions.
+        provider_name = (
+            workspace.config.issue_provider.name
+            if hasattr(workspace.config, "issue_provider")
+            else "issue provider"
+        )
+        raise BlockerError(
+            code="unknown_alias",
+            what=f"alias '{alias}' isn't a {provider_name} id, an issue URL, or a feature name",
+            details={"alias": alias, "provider": provider_name},
+            fix_actions=[
+                FixAction(
+                    action="list", args={}, safe=True,
+                    preview="canopy list shows all feature lanes",
+                ),
+            ],
+        )
 
     from ..features.coordinator import FeatureCoordinator
     features = FeatureCoordinator(workspace)._load_features()
@@ -164,19 +209,45 @@ def resolve_linear_id(workspace: Workspace, alias: str) -> str:
     linear_id = feature.get("linear_issue")
     if not linear_id:
         raise BlockerError(
-            code="no_linear_id",
-            what=f"feature '{feature_name}' has no linked Linear issue",
+            code="no_linked_issue",
+            what=f"feature '{feature_name}' has no linked issue",
             details={"alias": alias, "feature": feature_name},
             fix_actions=[
                 FixAction(
                     action="feature_link_linear",
                     args={"feature": feature_name, "issue": "<ID>"},
                     safe=True,
-                    preview="link a Linear issue ID to this feature lane",
+                    preview="link an issue id to this feature lane",
                 ),
             ],
         )
     return linear_id
+
+
+# Deprecated alias kept for back-compat with existing imports
+# (linear_get_issue, the legacy MCP tool, tests). New code calls
+# ``resolve_issue_id``.
+def resolve_linear_id(workspace: Workspace, alias: str) -> str:
+    """**Deprecated.** Renamed to ``resolve_issue_id`` (M5+).
+
+    Functionally equivalent — provider-aware when the workspace has an
+    ``[issue_provider]`` configured. The old name leaks Linear-ness;
+    new call sites should use ``resolve_issue_id``. The legacy error
+    code ``no_linear_id`` is also reissued as ``no_linked_issue``.
+    """
+    try:
+        return resolve_issue_id(workspace, alias)
+    except BlockerError as err:
+        # Surface the legacy code so existing assertions on
+        # ``no_linear_id`` keep working until callers migrate.
+        if err.code == "no_linked_issue":
+            raise BlockerError(
+                code="no_linear_id",
+                what=err.what,
+                details=err.details,
+                fix_actions=err.fix_actions,
+            ) from None
+        raise
 
 
 def resolve_pr_targets(workspace: Workspace, alias: str) -> list[PRTarget]:

--- a/src/canopy/actions/reads.py
+++ b/src/canopy/actions/reads.py
@@ -18,7 +18,7 @@ from ..providers import (
 from ..workspace.workspace import Workspace
 from .aliases import (
     BranchTarget, PRTarget,
-    resolve_branch_targets, resolve_linear_id, resolve_pr_targets,
+    resolve_branch_targets, resolve_issue_id, resolve_linear_id, resolve_pr_targets,
 )
 from .errors import BlockerError, FixAction
 
@@ -35,7 +35,7 @@ def issue_get(workspace: Workspace, alias: str) -> dict:
     is the legacy wrapper that exposes the raw provider state for
     pre-M5 callers — kept until they migrate.
     """
-    issue_id = resolve_linear_id(workspace, alias)
+    issue_id = resolve_issue_id(workspace, alias)
     provider = get_issue_provider(workspace)
     try:
         issue = provider.get_issue(issue_id)

--- a/src/canopy/cli/main.py
+++ b/src/canopy/cli/main.py
@@ -1762,6 +1762,63 @@ def cmd_issue(args: argparse.Namespace) -> None:
     console.print()
 
 
+def cmd_issues(args: argparse.Namespace) -> None:
+    """List the current user's open issues from the configured provider (F-5).
+
+    Mirrors ``mcp__canopy__issue_list_my_issues``. Empty list when the
+    provider isn't configured (no autocomplete signal). Each entry is
+    the canonical ``Issue.to_dict()`` shape.
+    """
+    from ..providers import (
+        IssueProviderError, ProviderNotConfigured, get_issue_provider,
+    )
+    from ..actions.errors import BlockerError, FixAction
+    from .render import render_blocker
+    from .ui import console
+
+    workspace = _load_workspace()
+    try:
+        provider = get_issue_provider(workspace)
+        issues = provider.list_my_issues(limit=args.limit)
+    except ProviderNotConfigured:
+        if args.json:
+            _print_json([])
+        else:
+            console.print("  [muted]no issue provider configured[/]")
+        return
+    except IssueProviderError as e:
+        err = BlockerError(
+            code="issue_provider_failed",
+            what="issue provider call failed",
+            details={"error": str(e)},
+            fix_actions=[
+                FixAction(action="doctor", args={}, safe=True,
+                            preview="canopy doctor surfaces provider config drift"),
+            ],
+        )
+        if args.json:
+            _print_json(err.to_dict())
+        else:
+            render_blocker(err, action="issues")
+        sys.exit(1)
+
+    items = [i.to_dict() for i in issues]
+    if args.json:
+        _print_json(items)
+        return
+    console.print()
+    if not items:
+        console.print("  [muted]no open issues[/]")
+        console.print()
+        return
+    for it in items:
+        identifier = it.get("identifier") or it.get("id") or ""
+        state = it.get("state") or ""
+        title = it.get("title") or ""
+        console.print(f"  [feature]{identifier}[/]  [muted]{state}[/]  {title}")
+    console.print()
+
+
 def cmd_pr(args: argparse.Namespace) -> None:
     """Fetch PR data per repo for an alias."""
     from ..actions.reads import github_get_pr
@@ -3010,13 +3067,23 @@ def main() -> None:
                          help="Limit to a specific feature lane")
     drift_p.add_argument("--json", action="store_true", help="Output as JSON")
 
-    # issue (Linear)
+    # issue — fetch one issue from the configured provider (M5+)
     issue_p = subparsers.add_parser(
         "issue",
-        help="Fetch a Linear issue (alias = ID like ENG-412 or feature alias)",
+        help="Fetch an issue from the workspace provider (Linear / GitHub Issues)",
     )
-    issue_p.add_argument("alias", help="Linear ID or feature alias")
+    issue_p.add_argument("alias",
+                          help="Provider-native id (SIN-412 / 5 / #5 / owner/repo#5 / URL) or feature alias")
     issue_p.add_argument("--json", action="store_true", help="Output as JSON")
+
+    # issues — list current user's open issues from the configured provider (F-5)
+    issues_p = subparsers.add_parser(
+        "issues",
+        help="List the current user's open issues from the workspace provider",
+    )
+    issues_p.add_argument("--limit", type=int, default=25,
+                            help="Max issues to return (default 25)")
+    issues_p.add_argument("--json", action="store_true", help="Output as JSON")
 
     # pr (GitHub)
     pr_p = subparsers.add_parser(
@@ -3122,6 +3189,7 @@ def main() -> None:
         "drift": cmd_drift,
         "run": cmd_run,
         "issue": cmd_issue,
+        "issues": cmd_issues,
         "pr": cmd_pr,
         "comments": cmd_comments,
         "switch": cmd_switch,

--- a/src/canopy/mcp/server.py
+++ b/src/canopy/mcp/server.py
@@ -1286,11 +1286,19 @@ def issue_get(alias: str) -> dict:
         IssueNotFoundError, ProviderNotConfigured, IssueProviderError,
         get_issue_provider,
     )
-    from ..actions.errors import BlockerError, FixAction
+    from ..actions.aliases import resolve_issue_id
+    from ..actions.errors import ActionError, BlockerError, FixAction
     ws = _get_workspace()
     try:
+        # Resolve through the M5 alias layer so feature names + provider-
+        # native ids both work: SIN-412 / 5 / #5 / owner/repo#5 / URL /
+        # auth-flow (looks up linked issue id from features.json).
+        try:
+            resolved = resolve_issue_id(ws, alias)
+        except ActionError as err:
+            return err.to_dict()
         provider = get_issue_provider(ws)
-        issue = provider.get_issue(alias)
+        issue = provider.get_issue(resolved)
     except ProviderNotConfigured as e:
         return BlockerError(
             code="issue_provider_not_configured",

--- a/src/canopy/providers/github_issues.py
+++ b/src/canopy/providers/github_issues.py
@@ -100,19 +100,27 @@ class GitHubIssuesProvider:
 
     def list_my_issues(self, limit: int = 50) -> list[Issue]:
         """Return open GitHub issues assigned to the current user, scoped
-        to the configured repo. Honors ``labels_filter`` when set."""
-        query_parts = [f"repo:{self.repo}", "is:open", "is:issue", "assignee:@me"]
+        to the configured repo. Honors ``labels_filter`` when set.
+
+        Uses ``gh issue list`` (not ``gh search issues``) — the search form
+        treats positional args as search *text*, so passing qualifiers like
+        ``repo:...`` and ``is:open`` quotes them as a single text token and
+        the API returns "Invalid search query." See test-findings F-10.
+        """
+        args = [
+            "issue", "list",
+            "--repo", self.repo,
+            "--state", "open",
+            "--assignee", "@me",
+            "--limit", str(limit),
+            "--json", "number,title,state,body,url,assignees,labels",
+        ]
         if self.labels_filter:
             for label in self.labels_filter:
-                query_parts.append(f'label:"{label}"')
-        query = " ".join(query_parts)
+                args.extend(["--label", label])
 
         try:
-            raw_list = _gh_json([
-                "search", "issues", query,
-                "--limit", str(limit),
-                "--json", "number,title,state,body,url,assignees,labels,repository",
-            ])
+            raw_list = _gh_json(args)
         except GitHubNotConfiguredError as e:
             raise ProviderNotConfigured(str(e)) from e
 
@@ -146,6 +154,28 @@ class GitHubIssuesProvider:
         raise NotImplementedError(
             "GitHubIssuesProvider.update_issue_state is not implemented in v1.",
         )
+
+    def parse_alias(self, alias: str) -> str | None:
+        """Recognize GitHub-shaped aliases. See ``_GH_ALIAS`` shapes.
+
+        Returns the canonical alias string (which ``get_issue`` can
+        consume) when recognized, ``None`` otherwise.
+        """
+        s = alias.strip()
+        # Full issue URL — return the issue id (provider knows its repo).
+        url_match = re.match(
+            r"^https?://github\.com/([\w\-.]+)/([\w\-.]+)/issues/(\d+)/?$", s,
+        )
+        if url_match:
+            owner, repo, num = url_match.group(1), url_match.group(2), url_match.group(3)
+            return f"{owner}/{repo}#{num}"
+        # owner/repo#N
+        if re.match(r"^[\w\-.]+/[\w\-.]+#\d+$", s):
+            return s
+        # #N or bare N
+        if re.match(r"^#?\d+$", s):
+            return s.lstrip("#")
+        return None
 
     # ── Internal ────────────────────────────────────────────────────────
 

--- a/src/canopy/providers/linear.py
+++ b/src/canopy/providers/linear.py
@@ -238,6 +238,19 @@ class LinearProvider:
             "Track via a future plan if you need write-back.",
         )
 
+    def parse_alias(self, alias: str) -> str | None:
+        """Recognize Linear-shaped IDs like ``ENG-412`` (``[A-Z]+-\\d+``).
+
+        Returns the alias unchanged when it matches; ``None`` otherwise
+        so the resolver falls back to feature-lane lookup.
+        """
+        if _LINEAR_ID_PATTERN.match(alias.strip()):
+            return alias.strip()
+        return None
+
+
+_LINEAR_ID_PATTERN = re.compile(r"^[A-Z]+-\d+$", re.IGNORECASE)
+
 
 # ── Module-level parsers (kept module-level so tests can mock easily) ──
 

--- a/src/canopy/providers/types.py
+++ b/src/canopy/providers/types.py
@@ -109,6 +109,28 @@ class IssueProvider(Protocol):
         """
         ...
 
+    def parse_alias(self, alias: str) -> str | None:
+        """Recognize a provider-native alias and return its canonical form.
+
+        Returns ``None`` when the alias doesn't look like one this
+        provider can handle — the caller (``actions/aliases.py``) then
+        falls through to feature-lane lookup.
+
+        Examples:
+          - ``LinearProvider.parse_alias("SIN-412")`` → ``"SIN-412"``
+          - ``LinearProvider.parse_alias("5")`` → ``None`` (Linear IDs need a team prefix)
+          - ``GitHubIssuesProvider.parse_alias("5")`` → ``"5"``
+          - ``GitHubIssuesProvider.parse_alias("#5")`` → ``"5"``
+          - ``GitHubIssuesProvider.parse_alias("owner/repo#5")`` → ``"owner/repo#5"``
+          - ``GitHubIssuesProvider.parse_alias("https://github.com/o/r/issues/5")`` → ``"5"``
+
+        Implementations should be cheap (regex / string ops) — no
+        network. The resolver may call this on every CLI input. Existing
+        v1 providers can default to a regex check; future providers
+        plug in their own native shapes.
+        """
+        ...
+
 
 # Provider exceptions. These are the only exceptions providers should
 # raise; the action layer catches them and converts to ``BlockerError``

--- a/tests/test_aliases.py
+++ b/tests/test_aliases.py
@@ -7,7 +7,8 @@ import pytest
 
 from canopy.actions.aliases import (
     BranchTarget, PRTarget,
-    resolve_branch_targets, resolve_feature, resolve_linear_id, resolve_pr_targets,
+    resolve_branch_targets, resolve_feature, resolve_issue_id,
+    resolve_linear_id, resolve_pr_targets,
 )
 from canopy.actions.errors import BlockerError
 from canopy.workspace.config import RepoConfig, WorkspaceConfig
@@ -136,6 +137,75 @@ def test_resolve_linear_id_no_link_raises(workspace_with_feature):
     with pytest.raises(BlockerError) as exc_info:
         resolve_linear_id(ws, "auth-flow")
     assert exc_info.value.code == "no_linear_id"
+
+
+# ── resolve_issue_id (M5+ provider-aware — F-7) ─────────────────────────
+
+
+def test_resolve_issue_id_linear_id_via_provider(workspace_with_feature):
+    """Linear-shaped ids are recognised by LinearProvider.parse_alias."""
+    ws = _make_workspace(workspace_with_feature)
+    assert resolve_issue_id(ws, "SIN-412") == "SIN-412"
+
+
+def test_resolve_issue_id_github_id_when_provider_swapped(workspace_with_feature):
+    """When the workspace selects github_issues, bare/hash/owner-repo forms work."""
+    from unittest.mock import patch
+    from canopy.providers.github_issues import GitHubIssuesProvider
+    ws = _make_workspace(workspace_with_feature)
+    provider = GitHubIssuesProvider({"repo": "owner/repo"}, workspace_root=workspace_with_feature)
+    # `aliases.py` imports get_issue_provider lazily inside the function — patch at the source module.
+    with patch("canopy.providers.get_issue_provider", return_value=provider):
+        assert resolve_issue_id(ws, "5") == "5"
+        assert resolve_issue_id(ws, "#5") == "5"
+        assert resolve_issue_id(ws, "owner/repo#5") == "owner/repo#5"
+        assert resolve_issue_id(ws, "https://github.com/owner/repo/issues/5") == "owner/repo#5"
+
+
+def test_resolve_issue_id_falls_back_to_feature_lookup(workspace_with_feature):
+    """When the alias isn't a provider-native id, walk features.json."""
+    _features_file(workspace_with_feature, {
+        "auth-flow": {
+            "repos": ["repo-a", "repo-b"], "status": "active",
+            "linear_issue": "SIN-99",
+        },
+    })
+    ws = _make_workspace(workspace_with_feature)
+    assert resolve_issue_id(ws, "auth-flow") == "SIN-99"
+
+
+def test_resolve_issue_id_unknown_alias_blocks(workspace_with_feature):
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},
+    })
+    ws = _make_workspace(workspace_with_feature)
+    with pytest.raises(BlockerError) as exc_info:
+        resolve_issue_id(ws, "neither-id-nor-feature")
+    assert exc_info.value.code == "unknown_alias"
+    # Provider name surfaced in the error so the user knows what shapes are expected
+    assert "provider" in (exc_info.value.details or {})
+
+
+def test_resolve_issue_id_feature_without_linked_issue_blocks(workspace_with_feature):
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},  # no linear_issue
+    })
+    ws = _make_workspace(workspace_with_feature)
+    with pytest.raises(BlockerError) as exc_info:
+        resolve_issue_id(ws, "auth-flow")
+    assert exc_info.value.code == "no_linked_issue"
+
+
+def test_resolve_linear_id_back_compat_reissues_legacy_code(workspace_with_feature):
+    """The deprecated wrapper preserves the old ``no_linear_id`` code so
+    existing assertions on it continue to work until callers migrate."""
+    _features_file(workspace_with_feature, {
+        "auth-flow": {"repos": ["repo-a"], "status": "active"},
+    })
+    ws = _make_workspace(workspace_with_feature)
+    with pytest.raises(BlockerError) as exc_info:
+        resolve_linear_id(ws, "auth-flow")
+    assert exc_info.value.code == "no_linear_id"   # legacy code preserved
 
 
 # ── resolve_branch_targets ───────────────────────────────────────────────

--- a/tests/test_providers_github_issues.py
+++ b/tests/test_providers_github_issues.py
@@ -131,8 +131,11 @@ def test_get_issue_empty_response_raises_not_found(tmp_path):
 # ── list_my_issues ───────────────────────────────────────────────────────
 
 
-def test_list_my_issues_builds_query(tmp_path):
-    p = _provider(tmp_path, labels_filter=["bug"])
+def test_list_my_issues_uses_gh_issue_list_with_flags(tmp_path):
+    """F-10: must use ``gh issue list`` with --repo/--state/--assignee/--label
+    flags. ``gh search issues`` treats positional arg as search text and
+    chokes on qualifiers like ``repo:owner/repo``."""
+    p = _provider(tmp_path, labels_filter=["bug", "p0"])
     captured: dict = {}
 
     def fake_gh(args):
@@ -146,13 +149,16 @@ def test_list_my_issues_builds_query(tmp_path):
         issues = p.list_my_issues()
     assert len(issues) == 2
     args = captured["args"]
-    # query is the third positional arg after "search", "issues"
-    query = args[2]
-    assert "repo:owner/repo" in query
-    assert "is:open" in query
-    assert "is:issue" in query
-    assert "assignee:@me" in query
-    assert 'label:"bug"' in query
+    # First two args are the subcommand. NOT "search issues".
+    assert args[:2] == ["issue", "list"]
+    # Qualifiers are CLI flags, not embedded in a search query.
+    assert "--repo" in args and args[args.index("--repo") + 1] == "owner/repo"
+    assert "--state" in args and args[args.index("--state") + 1] == "open"
+    assert "--assignee" in args and args[args.index("--assignee") + 1] == "@me"
+    # Both labels passed as separate --label flags
+    label_indices = [i for i, a in enumerate(args) if a == "--label"]
+    assert len(label_indices) == 2
+    assert {args[i + 1] for i in label_indices} == {"bug", "p0"}
 
 
 def test_list_my_issues_returns_empty_when_no_results(tmp_path):
@@ -225,3 +231,44 @@ def test_to_issue_falls_back_to_default_repo_for_url():
     raw = {"number": 7, "title": "x", "state": "open"}
     issue = _to_issue(raw, default_repo="default/repo")
     assert issue.url == "https://github.com/default/repo/issues/7"
+
+
+# ── parse_alias (M5+ Provider Protocol method — F-7) ────────────────────
+
+
+def test_parse_alias_bare_number(tmp_path):
+    p = _provider(tmp_path)
+    assert p.parse_alias("142") == "142"
+
+
+def test_parse_alias_hash_number(tmp_path):
+    p = _provider(tmp_path)
+    assert p.parse_alias("#142") == "142"
+
+
+def test_parse_alias_owner_repo_form(tmp_path):
+    p = _provider(tmp_path)
+    assert p.parse_alias("owner/repo#142") == "owner/repo#142"
+
+
+def test_parse_alias_full_url(tmp_path):
+    p = _provider(tmp_path)
+    out = p.parse_alias("https://github.com/owner/repo/issues/142")
+    assert out == "owner/repo#142"
+
+
+def test_parse_alias_url_with_trailing_slash(tmp_path):
+    p = _provider(tmp_path)
+    assert p.parse_alias("https://github.com/o/r/issues/9/") == "o/r#9"
+
+
+def test_parse_alias_returns_none_for_unrecognized(tmp_path):
+    p = _provider(tmp_path)
+    assert p.parse_alias("auth-flow") is None
+    assert p.parse_alias("SIN-412") is None
+    assert p.parse_alias("not an issue") is None
+
+
+def test_parse_alias_handles_whitespace(tmp_path):
+    p = _provider(tmp_path)
+    assert p.parse_alias("  142  ") == "142"

--- a/tests/test_providers_linear.py
+++ b/tests/test_providers_linear.py
@@ -249,3 +249,33 @@ def test_get_issue_without_root_raises_provider_error():
     p = LinearProvider({})
     with pytest.raises(IssueProviderError):
         p.get_issue("SIN-1")
+
+
+# ── parse_alias (M5+ Provider Protocol method — F-7) ────────────────────
+
+
+def test_parse_alias_recognises_linear_id(tmp_path):
+    p = _provider(tmp_path)
+    assert p.parse_alias("SIN-412") == "SIN-412"
+    assert p.parse_alias("ENG-1") == "ENG-1"
+    assert p.parse_alias("DOC-12345") == "DOC-12345"
+
+
+def test_parse_alias_case_insensitive(tmp_path):
+    p = _provider(tmp_path)
+    assert p.parse_alias("sin-7") == "sin-7"
+
+
+def test_parse_alias_handles_whitespace(tmp_path):
+    p = _provider(tmp_path)
+    assert p.parse_alias("  SIN-7  ") == "SIN-7"
+
+
+def test_parse_alias_returns_none_for_non_linear(tmp_path):
+    p = _provider(tmp_path)
+    # Bare numbers, GH-shaped, feature names — all None for Linear.
+    assert p.parse_alias("142") is None
+    assert p.parse_alias("#142") is None
+    assert p.parse_alias("owner/repo#142") is None
+    assert p.parse_alias("auth-flow") is None
+    assert p.parse_alias("https://github.com/o/r/issues/5") is None

--- a/tests/test_providers_registry.py
+++ b/tests/test_providers_registry.py
@@ -112,6 +112,9 @@ class _NoopProvider:
     def update_issue_state(self, alias, new_state):
         raise NotImplementedError
 
+    def parse_alias(self, alias):  # F-7
+        return alias
+
 
 class _CapturingProvider(_NoopProvider):
     def __init__(self, options=None, *, workspace_root=None):

--- a/tests/test_providers_types.py
+++ b/tests/test_providers_types.py
@@ -49,7 +49,7 @@ def test_exception_hierarchy():
 
 
 def test_protocol_runtime_check_minimal_impl():
-    """Anything with the four methods passes isinstance(obj, IssueProvider)."""
+    """Anything with the five methods passes isinstance(obj, IssueProvider)."""
 
     class Stub:
         def get_issue(self, alias):  # noqa: ARG002
@@ -63,6 +63,9 @@ def test_protocol_runtime_check_minimal_impl():
 
         def update_issue_state(self, alias, new_state):  # noqa: ARG002
             return None
+
+        def parse_alias(self, alias):  # noqa: ARG002 — F-7
+            return alias
 
     assert isinstance(Stub(), IssueProvider)
 


### PR DESCRIPTION
## Summary

Three related fixes from [docs/test-findings.md](https://github.com/ashmitb95/canopy/blob/main/docs/test-findings.md). The headline is **F-7 — provider-aware alias resolver** (the test plan's P0). F-10 was found incidentally while smoke-testing F-5.

## F-7 (P0) — `canopy issue` works for any provider

**Before:** `canopy issue 5` against a github_issues provider failed with `unknown_alias` because the resolver was hardcoded to look for Linear-shaped IDs (`SIN-412`). M5 shipped the Provider Protocol but the alias-resolution layer above it never learned about non-Linear shapes.

**After:** every alias form works:

```
canopy issue 5                                 → ✓
canopy issue '#5'                              → ✓
canopy issue 'owner/repo#5'                    → ✓
canopy issue 'https://github.com/o/r/issues/5' → ✓  (URL extracted to canonical "o/r#5")
canopy issue SIN-412                           → ✓  (Linear path unchanged)
canopy issue auth-flow                         → ✓  (feature alias unchanged)
```

**Design:** new `IssueProvider.parse_alias(alias) -> str | None` Protocol method. Returns canonicalised id when the provider recognises the shape; None falls through to feature-lane lookup. `LinearProvider.parse_alias` matches `[A-Z]+-\d+`; `GitHubIssuesProvider.parse_alias` matches bare/hash/owner-repo/URL. `resolve_linear_id` renamed to `resolve_issue_id` (provider-aware); old name kept as deprecated wrapper that preserves the legacy `no_linear_id` error code for back-compat. The MCP `issue_get` tool now also routes through `resolve_issue_id`, so feature aliases work there too.

## F-10 (incidental) — `gh search issues` query was malformed

**Found while verifying F-5.** `GitHubIssuesProvider.list_my_issues` built a query string like `repo:owner/repo is:open assignee:@me` and passed it positionally to `gh search issues`. But the search verb treats positional args as search *text* — the qualifiers got quoted as a single text token and the GitHub API returned `Invalid search query.`

Unit tests mocked `_gh_json` and asserted on constructed args, so they happily passed even though the args were nonsense to the real CLI. **This is exactly the gap the integration test plan was meant to catch — and did.**

Fix: switch to `gh issue list --repo ... --state open --assignee @me --label ...` (the right verb form, matches Phil's branch).

## F-5 (P2) — `canopy issues` plural

Added `cmd_issues` mirroring `mcp__canopy__issue_list_my_issues`. Empty list when no provider configured. Both `--json` and human-readable rendering of canonical Issue shape.

## Tests

+21 across:
- `test_aliases.py` — `resolve_issue_id` behaviour (Linear path, GH path with mocked provider, feature-lookup fallback, error codes); deprecated `resolve_linear_id` wrapper preserves legacy code.
- `test_providers_linear.py` — `parse_alias` matches Linear IDs only, returns None for GH-shaped / feature-name input.
- `test_providers_github_issues.py` — `parse_alias` matches bare/hash/owner-repo/URL; F-10 regression: `list_my_issues` uses `gh issue list` with the right flag set.
- `test_providers_types.py` + `test_providers_registry.py` — Protocol stubs gain `parse_alias` so `isinstance(stub, IssueProvider)` still passes.

Suite: 628 → 644 passing.

## Test plan

- [x] `python -m pytest -q` (644 pass)
- [x] Manual against canopy-test with `[issue_provider] = github_issues`:
  - `canopy issue 5`, `canopy issue '#5'`, `canopy issue '<URL>'` all return the canonical Issue shape
  - `canopy issues --json` returns `[]` (no assigned issues)
  - With one issue assigned: `canopy issues` renders `#5  in_progress  Test: ...`

## After this PR

Remaining from test-findings.md:
- **F-3** (doctor mcp_orphans check + reaper) — backlog, separate PR.
- **F-4** (docs/mcp.md OAuth-headless note) — small docs PR.