### PR TITLE
fix(cli,state): F-11 + F-12 from test-plan Run 2 + extended plan

### DIFF
--- a/docs/test-findings.md
+++ b/docs/test-findings.md
@@ -155,6 +155,59 @@ This is the recovery scenario M1 was built for. Detection works end-to-end again
 
 - ✅ Throwaway issues #5 + #6 on `ashmitb95/canopy-test-api` closed at end of run.
 - ✅ canopy-test workspace canopy.toml restored to original; README.md edits in test-api/test-ui reset.
+
+---
+
+# Test Run 2 — 2026-05-03 (canopy 0.5.0, post-Run-1 fixes)
+
+Second pass after [PR #16](https://github.com/ashmitb95/canopy/pull/16)/[#17](https://github.com/ashmitb95/canopy/pull/17)/[#18](https://github.com/ashmitb95/canopy/pull/18)/[#19](https://github.com/ashmitb95/canopy/pull/19)/[#20](https://github.com/ashmitb95/canopy/pull/20) landed. Extended test-plan.md with §6–§12 covering pre-M0 and cross-cutting flows that Run 1 didn't touch (switch, state machine, commit/push semantics, drift detection, universal aliases, stash family, doctor `--fix`).
+
+## Section results (Run 2)
+
+| Section | Result | Notes |
+|---|---|---|
+| §6 switch (6) | ✅ 6/6 | Linear ID + feature alias both resolve; `--release-current` mode works; switch back from warm is fast (~110 ms); fresh feature creates branches. |
+| §7 state machine (9) | ✅ 5/9, ⏭️ 4 | drifted, in_progress, ready_to_commit, ready_to_push, needs_work all reachable. awaiting_review/approved/awaiting_bot_resolution/no_prs blocked on real PR setup. |
+| §8 commit/push (8) | ✅ 4/8, ⏭️ 4 | empty_message + wrong_branch blockers fire; per-repo subset works; bad path correctly fails (intentional). Push tests skipped to avoid creating remote branches. |
+| §9 drift (4) | ✅ 4/4 | Live + cached drift agree; switch recovers; doctor surfaces heads_stale during drift. |
+| §10 universal aliases (6) | ✅ 6/6 | Feature name, Linear ID, `<repo>#<n>`, PR URL, bare GH issue (with provider swap), unknown alias all behave as designed. |
+| §11 stash family (5) | ✅ 4/5 | All feature-tagged operations work via `--feature` flag; one initial confusion about syntax (see retraction). |
+| §12 doctor --fix (6) | ✅ 5/6 | Real workspace went from 6 errors / 2 warnings / 1 info → 0 / 0 / 1 (vsix gated). 12.4 (`--clean-vsix`) skipped to avoid touching live extension installs. |
+
+## New findings
+
+### F-11: `canopy preflight` (no feature arg) doesn't persist a record (FIXED — this PR)
+
+When run from the workspace root (vs. from inside a worktree), `canopy preflight` skipped the `record_result` call because `ctx.feature` was None — even though `active_feature.json` had a canonical feature whose repos matched. Result: `feature_state` couldn't transition `in_progress → ready_to_commit` for the canonical feature without an explicit `--feature` arg, breaking the most natural workflow.
+
+**Fix:** in `cmd_preflight`, fall back to `active_feature.read_active(ws).feature` when `ctx.feature` is None. Verified: `canopy preflight` from workspace root now writes the record; `canopy state <canonical>` immediately reports `ready_to_commit`.
+
+### F-12: drifted state surfaces deprecated `realign` for main-tree (FIXED — this PR)
+
+Per CLAUDE.md, `realign` was deprecated from CLI/MCP in Wave 2.9 — replaced by the canonical-slot `switch` primitive which handles main-tree and worktree-backed features uniformly. But `_drifted_result` in `feature_state.py` still surfaced `realign` as the primary CTA for main-tree features (the worktree branch already used `switch`).
+
+**Fix:** main-tree drifted now also surfaces `switch` (with the same per-repo preview text). `tests/test_feature_state.py:test_drift_state_supersedes_everything` assertion updated.
+
+### F-13: misread — feature stash variants exist via `--feature` flag
+
+Initial run of §11 used `canopy stash save-feature` / `list-grouped` / `pop-feature` and got argparse errors. **Retracted on second look** — the feature variants are accessed via `--feature <name>` on the regular subcommands (`canopy stash save --feature ...` routes internally to `cmd_stash_save_feature`). Functionality works; my test plan had the wrong syntax. Plan §11 updated.
+
+### Plan-expectation corrections (not bugs)
+
+- **§8.5** — bad `--paths` filter produces `failed` (git add errors fatally on missing pathspec), not `nothing`. Original plan expectation was wrong; updated to reflect intentional fail-loud behavior.
+- **§11 JSON shape** — actual response shape is `{by_feature: {...}, untagged: [...]}`, not `{<feature>: [...]}`. Plan updated.
+- **§12.6 syntax** — flag is `--fix-category <name>`, not `--fix=<name>`. Plan updated.
+- **§6 disjoint-repo evacuation** — when a feature spans only some repos, switching to a different feature with disjoint repos leaves the unaffected repos on whatever branch they were on, with no warm-tree evacuation (`evacuation: None`). Sensible behavior, not a bug; worth noting for users who expect more.
+
+## Headline
+
+Run 2 found **2 real bugs (F-11, F-12), both fixed in the same PR**. The MCP/agent surface continues to be healthy; the bugs were both in CLI ergonomics. Combined with Run 1's findings, the cumulative tally is:
+
+- 13 findings filed (F-0 through F-12, plus F-13 retracted)
+- 11 fixed
+- 2 retracted (F-2, F-13 — measurement / syntax errors on the test side)
+
+Test-plan.md now covers §0–§13 (excluding the deferred §4 bot-tracking and §6 of the old composite scenario). §6–§12 are first-time tests for pre-M0 + cross-cutting flows. The plan is repeat-runnable; suggested cadence is once per release.
 - 🟡 Memory file `~/projects/canopy-test/.canopy/memory/sin-7-empty-state.{md,jsonl}` left in place — it's gitignored per M4's auto-write, harmless. Cleanup instruction: `rm -rf ~/projects/canopy-test/.canopy/memory/` if a fully fresh state is wanted.
 
 ## Headline takeaway

--- a/docs/test-plan.md
+++ b/docs/test-plan.md
@@ -24,7 +24,7 @@ Status: `[ ]` `[ ]` `[ ]` `[ ]` `[ ]`
 
 ---
 
-## 1. M1 — `canopy doctor` (16 categories + version handshake)
+## 1. M1 — `canopy doctor` (17 categories + version handshake)
 
 | # | Check | Steps | Expected |
 |---|---|---|---|
@@ -121,7 +121,126 @@ Status: `[ ]` × 11
 
 ---
 
-## 6. End-to-end scenario (composite)
+## 6. `canopy switch` — canonical-slot focus primitive
+
+Switch is the primitive every other action depends on. It moves features between {canonical, warm, cold} states; the cap (`max_worktrees`, default 2) protects against unbounded warm-tree growth.
+
+| # | Check | Steps | Expected |
+|---|---|---|---|
+| 6.1 | switch by feature name | `cd canopy-test && canopy switch sin-7-empty-state --json` | `feature: sin-7-empty-state`, `mode: active_rotation` (or `wind_down`); `per_repo_paths` populated; `memory` field present (M4). Previously canonical evacuates to warm. |
+| 6.2 | switch by Linear ID alias | `canopy switch SIN-6 --json` | Resolves to `sin-6-cache-stats`; same response shape. |
+| 6.3 | active_feature.json updated | `cat .canopy/state/active_feature.json` after 6.2 | `feature == "sin-6-cache-stats"`; `last_touched` map updated. |
+| 6.4 | switch with --release-current (wind-down) | `canopy switch sin-7-empty-state --release-current --json` | Previously-canonical (sin-6) goes cold (no warm worktree, may have feature-tagged stash if dirty); `evacuation` field absent. |
+| 6.5 | switch back uses warm | After 6.1/6.2 with active rotation: `canopy switch <previously-canonical>` | Fast (≤500 ms typical); reads from existing warm worktree. |
+| 6.6 | switch fresh feature creates branches | `canopy switch SIN-9 --json` (assumes no `sin-9-*` lane exists) | Creates branches from default per repo; `branches_created` populated in response. |
+
+Status: `[ ]` × 6
+
+---
+
+## 7. The 9-state machine — all transitions reachable
+
+`feature_state` is the dashboard backend. Every state should be reachable through the right preconditions; this exercises each branch of `_decide_state`.
+
+| # | State | How to reach | Check |
+|---|---|---|---|
+| 7.1 | `drifted` | Manual `git checkout main` in one feature repo | `canopy state <f>` returns `drifted`; primary action is `switch` (post-F-12 — was `realign` pre-fix). |
+| 7.2 | `in_progress` | Switch to feature, edit a file, no preflight | `state == "in_progress"`; primary action `preflight`. |
+| 7.3 | `ready_to_commit` | After 7.2: run `canopy preflight` (passes) | `state == "ready_to_commit"`; primary `commit`. |
+| 7.4 | `ready_to_push` | After 7.3: `canopy commit -m "..."` | `state == "ready_to_push"`; primary `push`. |
+| 7.5 | `awaiting_review` | After 7.4: `canopy push --set-upstream` + open PR | `state == "awaiting_review"`; primary `refresh`. |
+| 7.6 | `approved` | Manually mark PR APPROVED on GitHub | `state == "approved"`; primary `merge`. |
+| 7.7 | `awaiting_bot_resolution` | (M3) PR with only bot comments, no human action | covered by §4 — blocked on CodeRabbit. |
+| 7.8 | `needs_work` | Reviewer requests changes OR ≥1 actionable human comment | `state == "needs_work"`; primary `address_review_comments`. |
+| 7.9 | `no_prs` | New feature, clean tree, no PR yet | `state == "no_prs"`; primary `pr_create`. |
+
+Status: `[ ]` × 9
+
+---
+
+## 8. `canopy commit` + `canopy push` lifecycle (Wave 2.3)
+
+| # | Check | Steps | Expected |
+|---|---|---|---|
+| 8.1 | commit with no message blocks | `canopy commit` (no `-m`) | `BlockerError(code='empty_message')`; exit 1; nothing commits. |
+| 8.2 | commit succeeds across all repos in lane | Switch to a multi-repo feature; edit one file in each; `canopy commit -m "test"` | Per-repo result `ok` for each; SHAs returned; `files_changed: 1` per repo. |
+| 8.3 | commit blocks on wrong_branch | Manually checkout a different branch in one repo, then `canopy commit -m "x"` | `BlockerError(code='wrong_branch')`; per-repo `expected`/`actual` map; **no repo commits** (atomic pre-flight). |
+| 8.4 | commit per-repo subset | `canopy commit --repo test-api -m "..."` | Only `test-api` commits; `test-ui` not in results. |
+| 8.5 | commit with bad path filter | `canopy commit --paths nonexistent.txt -m "..."` | `failed` status — `git add nonexistent.txt` errors fatally; canopy surfaces the git error in `reason`. (Soft-failing would mask user typos; verified intentional.) |
+| 8.6 | push with no upstream blocks | First push of a fresh branch: `canopy push` | `BlockerError(code='no_upstream')`; fix-action carries `--set-upstream`. |
+| 8.7 | push with --set-upstream succeeds | `canopy push --set-upstream` | Per-repo result `ok`; remote branch created. |
+| 8.8 | push when nothing to push | Re-run `canopy push` after 8.7 | `up_to_date` status per repo; no error. |
+
+Status: `[ ]` × 8
+
+---
+
+## 9. Drift detection + recovery
+
+The hook + `heads.json` give us cached drift detection; live `feature_state` is the source of truth. Both should agree, and `switch` should recover from any induced drift.
+
+| # | Check | Steps | Expected |
+|---|---|---|---|
+| 9.1 | Live drift detection | Switch to a multi-repo feature; manually `git checkout main` in one repo. `canopy state <f>` | `state == "drifted"`; `repos.<repo>.is_drifted` or similar marker. |
+| 9.2 | `canopy drift` cached path | After 9.1, `canopy drift --json` | Reports the same drift. (Cached path uses `heads.json` — should still see it after the post-checkout hook fires.) |
+| 9.3 | switch recovers | `canopy switch <f>` after 9.1 | All repos back on the feature branch; `state == ...` (in_progress / no_prs / etc., not `drifted`). |
+| 9.4 | drift survives doctor scan | `canopy doctor` while drifted | Reports `heads_stale` for the repo (live HEAD ≠ heads.json); `auto_fixable: true`. |
+
+Status: `[ ]` × 4
+
+---
+
+## 10. Universal aliases — every read tool agrees on shape
+
+Aliases were rewritten in PR #19 to be provider-aware. Verify the alias surface is consistent across CLI commands.
+
+| # | Alias form | Expected behaviour across `state`, `comments`, `branch`, `issue` |
+|---|---|---|
+| 10.1 | Feature name (`sin-7-empty-state`) | All resolve to the same feature; same `feature` field. |
+| 10.2 | Linear ID (`SIN-7`) | Resolves to `sin-7-empty-state` via `linear_issue` field. |
+| 10.3 | `<repo>#<n>` for PR commands | `canopy pr test-api#1` and `canopy comments test-api#1` work. |
+| 10.4 | PR URL | `canopy pr 'https://github.com/o/r/pull/1'` works. |
+| 10.5 | Bare GH issue # (with provider swapped) | Per F-7 fix: `canopy issue 5` works when `[issue_provider] = github_issues`. |
+| 10.6 | Unknown alias | Surfaces `BlockerError(code='unknown_alias')` with `expected.explicit_features` listing real lanes. |
+
+Status: `[ ]` × 6
+
+---
+
+## 11. Feature-tagged stash family
+
+Stash should be feature-aware: tagged on save, groupable on list, restorable on pop.
+
+| # | Check | Steps | Expected |
+|---|---|---|---|
+| 11.1 | save with --feature tags the stash | Edit a file; `canopy stash save --feature <feature> -m "wip auth"` | Stash entry created; `git stash list` shows `[canopy <feature> @ <ts>] wip auth`. (Note: feature variants live behind the `--feature` flag, not as separate subcommands.) |
+| 11.2 | list with --feature clusters by feature | `canopy stash list --feature <feature> --json` | Returns `{by_feature: {<feature>: [{repo, index, ref, message, feature, ts, user_message}]}, untagged: [...]}`. |
+| 11.3 | pop with --feature restores | Switch to clean state; `canopy stash pop --feature <feature>` | Latest stash for that feature applied; working tree dirty again. |
+| 11.4 | save without --feature is plain stash | `canopy stash save -m "plain"` | Stash created but appears under `untagged` in `list --feature` output. |
+| 11.5 | drop removes a stash | `canopy stash drop --index 0` | Removed; `git stash list` confirms. |
+
+Status: `[ ]` × 5
+
+---
+
+## 12. `canopy doctor --fix` (close M1's repair loop)
+
+Run §1.1 already exercised the *detection* side. This section validates the *repair* side end-to-end against canopy-test's real drift (8 issues found in Run 1).
+
+| # | Check | Steps | Expected |
+|---|---|---|---|
+| 12.1 | Auto-fixable issues exist | `canopy doctor --json` | `summary.errors > 0` OR `summary.warnings > 0` with `auto_fixable: true`. |
+| 12.2 | `--fix` repairs heads_stale | `canopy doctor --fix --json` (no `--clean-vsix`) | `fixed[]` includes `heads_stale` entries with `success: true`. Re-run shows them gone. |
+| 12.3 | `--fix` repairs worktree_missing | Same `--fix` run | `worktree_missing` entries either `success: true` (worktree recreated) or `success: false` with a clear `error`. |
+| 12.4 | `--clean-vsix` opt-in | `canopy doctor --fix --clean-vsix --json` | Removes all but newest `singularityinc.canopy-*` extension dirs. (Verify with `ls ~/.vscode/extensions/`.) |
+| 12.5 | `mcp_orphans` repair (F-3) | If any orphans present, `canopy doctor --fix --json` | `fixed[]` includes `mcp_orphans` with `success: true`; PIDs killed. |
+| 12.6 | category filter | `canopy doctor --fix --fix-category heads --json` | Only `heads_stale` repaired; other auto-fixable issues stay. (Flag is `--fix-category <name>`, not `--fix=<name>`.) |
+
+Status: `[ ]` × 6
+
+---
+
+## 13. End-to-end scenario (composite)
 
 One realistic feature lifecycle that exercises every shipped milestone in sequence. Plan ~30 minutes.
 
@@ -181,7 +300,7 @@ canopy doctor
 
 ---
 
-## 7. Known unverifiable / deferred
+## 14. Known unverifiable / deferred
 
 These are intentionally not testable in v1 — note them but skip:
 
@@ -198,7 +317,7 @@ These are intentionally not testable in v1 — note them but skip:
 
 ---
 
-## 8. After running this plan
+## 15. After running this plan
 
 1. **Record results** — fill in checkboxes in this file and commit (or paste the diff in a session note).
 2. **Triage failures** — each `[✗]` becomes either a bug fix (file an issue), a docs gap (clarify in the relevant SKILL.md / concepts.md), or a known limitation (move into §7).

--- a/src/canopy/actions/feature_state.py
+++ b/src/canopy/actions/feature_state.py
@@ -487,11 +487,12 @@ def _drifted_result(
     drifted = drift_info["drifted_repos"]
     missing = drift_info["missing_repos"]
 
-    # For worktree-backed features, "drifted" usually means the worktree
-    # was manually checked out off-branch — `realign` would touch main and
-    # is the wrong fix. Suggest `switch` (which warms / re-checks out) or
-    # `done` (clean up the broken worktree). For main-tree features the
-    # original realign suggestion is correct.
+    # F-12: post-Wave 2.9, the canonical-slot model handles both worktree
+    # and main-tree recovery via ``switch``. The deprecated ``realign``
+    # action is no longer surfaced as the primary CTA for either case;
+    # ``switch`` re-establishes the feature context regardless of where
+    # the feature lives. ``done`` stays as a secondary CTA on the
+    # worktree path so users can intentionally drop a broken worktree.
     if has_worktrees:
         next_actions = [
             {"action": "switch", "args": {"feature": feature_name},
@@ -506,8 +507,8 @@ def _drifted_result(
         ]
     else:
         next_actions = [
-            {"action": "realign", "args": {"feature": feature_name},
-             "primary": True, "label": "Realign",
+            {"action": "switch", "args": {"feature": feature_name},
+             "primary": True, "label": "Switch",
              "preview": (
                  f"checkout expected branch in "
                  f"{', '.join(drifted + missing)}"

--- a/src/canopy/cli/main.py
+++ b/src/canopy/cli/main.py
@@ -1176,7 +1176,27 @@ def _cmd_preflight_context(args: argparse.Namespace) -> None:
     # IN_PROGRESS from READY_TO_COMMIT. Maps detect_context's directory
     # names back to canopy-registered repo names so feature_state
     # (which uses canonical names) can match.
-    if ctx.feature and ctx.workspace_root:
+    #
+    # F-11: when run from the workspace root (not inside a worktree),
+    # ``ctx.feature`` is None — but we may still have a canonical
+    # feature in ``active_feature.json`` whose repos overlap. Fall back
+    # to that so `canopy preflight` from the workspace root persists a
+    # record for the canonical feature, which is what `canopy state`
+    # then keys off to surface ready_to_commit.
+    feature_for_record = ctx.feature
+    if feature_for_record is None and ctx.workspace_root:
+        try:
+            from ..actions import active_feature as _af
+            from ..workspace.config import load_config as _load_config
+            from ..workspace.workspace import Workspace as _WS
+            _ws = _WS(_load_config(ctx.workspace_root))
+            _active = _af.read_active(_ws)
+            if _active and _active.feature:
+                feature_for_record = _active.feature
+        except Exception:
+            pass
+
+    if feature_for_record and ctx.workspace_root:
         try:
             from ..actions.preflight_state import record_result
             from ..workspace.config import load_config
@@ -1196,7 +1216,7 @@ def _cmd_preflight_context(args: argparse.Namespace) -> None:
                 head_sha_per_repo[canonical] = git_repo.head_sha(path)
             if head_sha_per_repo:
                 record_result(
-                    ctx.workspace_root, ctx.feature,
+                    ctx.workspace_root, feature_for_record,
                     passed=all_passed,
                     head_sha_per_repo=head_sha_per_repo,
                     summary=("preflight passed" if all_passed

--- a/tests/test_feature_state.py
+++ b/tests/test_feature_state.py
@@ -69,7 +69,10 @@ def test_drift_state_supersedes_everything(workspace_with_feature):
         result = feature_state(ws, "auth-flow")
 
     assert result["state"] == "drifted"
-    assert result["next_actions"][0]["action"] == "realign"
+    # F-12: post-Wave 2.9 the canonical-slot ``switch`` is the universal
+    # recovery primitive for both worktree and main-tree drift; the
+    # deprecated ``realign`` is no longer surfaced.
+    assert result["next_actions"][0]["action"] == "switch"
     assert "repo-b" in result["summary"]["alignment"]["drifted_repos"]
 
 


### PR DESCRIPTION
## Summary

Two bugs from the second integration test run, both fixed. Plus the test plan extended with §6–§12 covering pre-M0 + cross-cutting flows that Run 1 never touched (switch, state machine, commit/push semantics, drift, aliases, stash, doctor `--fix`).

See the new "Test Run 2" section in [docs/test-findings.md](https://github.com/ashmitb95/canopy/blob/fix/test-run-2-findings/docs/test-findings.md) for full results.

## F-11 — `canopy preflight` (no `--feature`) doesn't persist a record

**Before:** running `canopy preflight` from the workspace root (vs. inside a worktree) skipped `record_result` because `ctx.feature` was None — even when `active_feature.json` had a canonical feature whose repos matched. The `in_progress → ready_to_commit` state transition was broken for the most natural workflow ("preflight in workspace root, then check state").

**After:** `cmd_preflight` falls back to `active_feature.read_active(ws).feature` when `ctx.feature` is None. Verified end-to-end against canopy-test.

## F-12 — drifted state surfaces deprecated `realign`

Per CLAUDE.md, `realign` was deprecated from CLI/MCP in Wave 2.9, replaced by canonical-slot `switch`. The worktree branch in `_drifted_result` already used `switch`; the main-tree branch was still surfacing `realign`. Fixed both now use `switch` uniformly. `tests/test_feature_state.py:test_drift_state_supersedes_everything` updated to match.

## Test plan extension (§6–§12)

New sections covering 44 checks across 7 surfaces:

| Section | Surface | Checks |
|---|---|---|
| §6 | `canopy switch` (canonical-slot model) | 6 |
| §7 | 9-state machine transitions | 9 (5 verified, 4 blocked on real PRs) |
| §8 | commit + push lifecycle | 8 (4 verified, 4 skipped to avoid remote side effects) |
| §9 | drift detection + recovery | 4 |
| §10 | universal aliases across `state`/`pr`/`comments`/`issue` | 6 |
| §11 | feature-tagged stash family | 5 |
| §12 | doctor `--fix` (close M1's repair loop) | 6 |

Headline observations:
- Switch + drift recovery work as designed.
- doctor `--fix` repaired all 8 real issues canopy-test had accumulated (heads_stale, worktree_missing × 6, skill_stale → 0 remaining).
- The MCP/agent surface continues to be healthy across new tests; the bugs (F-11, F-12) are CLI ergonomics again — same pattern as Run 1.

## Plan-expectation corrections (not bugs)

- §7.1 primary CTA: `switch` (post-F-12 fix)
- §8.5 status: `failed` not `nothing` (git correctly errors on missing pathspec)
- §11 stash syntax: `--feature` flag on existing subcommands; JSON shape is `{by_feature, untagged}`
- §12.6 doctor scoping flag: `--fix-category <name>`, not `--fix=<name>`

These are docs fixes only.

## Cumulative findings tally (Run 1 + Run 2)

13 filed → 11 fixed, 2 retracted (F-2, F-13 — measurement / syntax errors on the test side, caught and documented).

## Test plan

- [x] `python -m pytest -q` (651 pass)
- [x] Manual against canopy-test:
  - F-11: `canopy preflight` from workspace root persists record; `canopy state <canonical>` reports `ready_to_commit`
  - F-12: `canopy state <drifted>` returns `next_actions[0].action == "switch"`
- [x] Run 2 §6–§12 executed; results recorded in test-findings.md

## Remaining

- §4 (bot-tracking) blocked on CodeRabbit setup on a test PR.
- §7.5/§7.6/§7.8 (PR-state machine cases) need real PRs with reviews/approvals.
- §8.6–§8.8 (push tests) deferred to avoid creating remote branches.
- §12.4 (vsix `--clean-vsix`) deferred — destructive on real install dir.

None of these are blocking; they're externally-gated.