### PR TITLE
infra: publish canopy-cli to PyPI on tag

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,36 @@
+name: Publish to PyPI
+
+on:
+  push:
+    tags:
+      - "v*"
+
+jobs:
+  build-and-publish:
+    name: Build and publish to PyPI
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write  # OIDC for PyPI trusted publishing
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Build sdist and wheel
+        run: |
+          python -m pip install --upgrade pip build
+          python -m build
+
+      - name: Verify version matches tag
+        run: |
+          TAG_VERSION="${GITHUB_REF_NAME#v}"
+          PKG_VERSION=$(python -c "import re,pathlib; print(re.search(r'__version__\s*=\s*\"([^\"]+)\"', pathlib.Path('src/canopy/__init__.py').read_text()).group(1))")
+          if [ "$TAG_VERSION" != "$PKG_VERSION" ]; then
+            echo "::error::Tag v$TAG_VERSION does not match __version__ ($PKG_VERSION)"
+            exit 1
+          fi
+
+      - name: Publish to PyPI
+        uses: pypa/gh-action-pypi-publish@release/v1

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -3,17 +3,33 @@ requires = ["hatchling"]
 build-backend = "hatchling.build"
 
 [project]
-name = "canopy"
+name = "canopy-cli"
 dynamic = ["version"]
-description = "Workspace-first development orchestrator"
+description = "Workspace-first development orchestrator for AI coding agents"
 readme = "README.md"
 requires-python = ">=3.10"
 license = "MIT"
+classifiers = [
+    "Development Status :: 4 - Beta",
+    "Intended Audience :: Developers",
+    "License :: OSI Approved :: MIT License",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: 3.12",
+    "Topic :: Software Development :: Version Control :: Git",
+]
+
 dependencies = [
     "tomli>=2.0; python_version < '3.11'",
     "mcp>=1.0",
     "rich>=13.0",
 ]
+
+[project.urls]
+Homepage = "https://github.com/ashmitb95/canopy"
+Source = "https://github.com/ashmitb95/canopy"
+Issues = "https://github.com/ashmitb95/canopy/issues"
 
 [project.optional-dependencies]
 graph = [


### PR DESCRIPTION
## Summary
- Rename distribution to `canopy-cli` (the name `canopy` is already taken on PyPI by an unrelated project). Executable names (`canopy`, `canopy-mcp`) are unchanged.
- Add `[project.urls]` + PyPI classifiers so the PyPI listing has the right metadata.
- Add `.github/workflows/publish.yml` — tag-triggered (`v*`) build + OIDC publish via PyPI trusted publishing. Workflow guards against tag/version mismatch.

## Why
Currently the only install path is cloning the repo and running `pip install -e .`. Publishing to PyPI unlocks `pipx install canopy-cli`, which is the cross-platform single-command install we need before doing the VSCode extension install-decoupling work.

## Release flow once merged
1. PyPI account + pending publisher for project `canopy-cli` are configured (done).
2. `git tag v3.1.0 && git push origin v3.1.0` → workflow builds sdist + wheel, OIDC-authenticates, publishes.
3. PyPI creates the project on first successful publish.

## Test plan
- [x] `python -m build` runs cleanly locally → `canopy_cli-3.1.0.tar.gz` + `canopy_cli-3.1.0-py3-none-any.whl`
- [x] `python -m twine check dist/*` → both PASSED
- [ ] After merge: push `v3.1.0` tag and verify workflow publishes to PyPI
- [ ] Verify `pipx install canopy-cli` works from a clean machine and `canopy --version` returns 3.1.0