### PR TITLE
fix(mcp): canopy-mcp --help (v3.1.1)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,14 @@ Tracks the Python side (CLI + MCP server). The VSCode extension has its own [vsc
 
 Versions follow semver. Pre-1.0 — minor bumps may add features or break behavior; the README is the source-of-truth contract.
 
+## 3.1.1 — 2026-05-31
+
+### Fixed
+- `canopy-mcp --help` / `-h` now prints usage and exits instead of starting the
+  stdio server and crashing on an empty stdin read. The MCP entry point is not
+  meant to be invoked interactively; the help text says so and points at
+  `canopy setup-agent`.
+
 ## 3.1.0 — 2026-05-30 (Plan 2 — Feature Resume)
 
 ### Added

--- a/src/canopy/__init__.py
+++ b/src/canopy/__init__.py
@@ -1,2 +1,2 @@
 """Canopy — workspace-first development orchestrator."""
-__version__ = "3.1.0"
+__version__ = "3.1.1"

--- a/src/canopy/mcp/server.py
+++ b/src/canopy/mcp/server.py
@@ -1790,6 +1790,22 @@ def main():
         from .. import __version__
         print(f"canopy-mcp {__version__}")
         return
+    if len(sys.argv) > 1 and sys.argv[1] in ("--help", "-h"):
+        print(
+            "canopy-mcp — Canopy MCP server (stdio JSON-RPC)\n"
+            "\n"
+            "This is a Model Context Protocol server. It is not run interactively;\n"
+            "your MCP-aware client (Claude Code, Claude Desktop, etc.) launches it\n"
+            "and communicates with it over stdio.\n"
+            "\n"
+            "To register canopy with Claude Code, run:\n"
+            "    canopy setup-agent\n"
+            "\n"
+            "Options:\n"
+            "  -V, --version    Print version and exit\n"
+            "  -h, --help       Print this message and exit"
+        )
+        return
     mcp.run(transport="stdio")
 
 


### PR DESCRIPTION
## Summary
`canopy-mcp --help` used to fall through to `mcp.run(transport="stdio")`, read EOF from the TTY, and crash with a Pydantic JSON validation error. That's the first thing a fresh `pipx install canopy-cli` user hits when they try to inspect the binary. Adds explicit `--help` / `-h` handling that prints usage and exits, mirroring the existing `--version` branch.

## Why a patch release
The bad UX ships in v3.1.0 (just published to PyPI). Cutting v3.1.1 immediately so new pipx-installers don't trip on it.

## Test plan
- [x] `canopy-mcp --help` and `-h` print usage and exit cleanly
- [x] `canopy-mcp --version` still prints `canopy-mcp 3.1.1`
- [x] `canopy-mcp` with no args still starts the stdio server (no behavior change)
- [ ] CI green
- [ ] After merge: tag `v3.1.1`, workflow publishes `canopy-cli 3.1.1` to PyPI