### PR TITLE
infra: add Release workflow (one-click tag + publish)

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,43 @@
+name: Release (tag from __version__)
+
+on:
+  workflow_dispatch:
+
+permissions:
+  contents: write  # needed to push the tag
+
+jobs:
+  tag:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - uses: actions/setup-python@v5
+        with:
+          python-version: "3.12"
+
+      - name: Read __version__
+        id: ver
+        run: |
+          V=$(python -c "import re,pathlib; print(re.search(r'__version__\s*=\s*\"([^\"]+)\"', pathlib.Path('src/canopy/__init__.py').read_text()).group(1))")
+          echo "version=$V" >> "$GITHUB_OUTPUT"
+          echo "Will release v$V"
+
+      - name: Refuse if tag already exists
+        run: |
+          if git rev-parse -q --verify "refs/tags/v${{ steps.ver.outputs.version }}" >/dev/null; then
+            echo "::error::Tag v${{ steps.ver.outputs.version }} already exists. Bump __version__ first."
+            exit 1
+          fi
+
+      - name: Configure git identity
+        run: |
+          git config user.name  "github-actions[bot]"
+          git config user.email "41898282+github-actions[bot]@users.noreply.github.com"
+
+      - name: Tag and push
+        run: |
+          git tag "v${{ steps.ver.outputs.version }}"
+          git push origin "v${{ steps.ver.outputs.version }}"


### PR DESCRIPTION
## Summary
Replace the manual `git tag vN.N.N && git push origin vN.N.N` release step with a one-click workflow.

`Release (tag from __version__)` is a `workflow_dispatch` action. When you click **Run workflow** in the Actions UI, it:
1. Reads `__version__` from `src/canopy/__init__.py`
2. Refuses if `vN.N.N` already exists (so you must bump first)
3. Creates and pushes the tag

The existing `publish.yml` is unchanged — it still fires on tag push and OIDC-publishes to PyPI.

## New release flow
1. Merge a PR that bumps `__version__` (and `CHANGELOG.md`)
2. Go to **Actions → Release (tag from __version__) → Run workflow**
3. Done. PyPI gets `canopy-cli vN.N.N` ~30s later.

## Test plan
- [ ] Merge this PR
- [ ] Merge PR #28 (canopy-mcp --help fix, bumps to 3.1.1)
- [ ] Click "Run workflow" on the Release action → confirm tag `v3.1.1` is pushed
- [ ] Confirm `publish.yml` fires on the tag push and publishes `canopy-cli 3.1.1` to PyPI